### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v1.1.0]
+
+Announcement: Author of Kete (Dar Dahlen) has left IPAC Caltech to begin a PhD at
+TU Braunschweig in Germany. Kete has been forked from the public copy maintained by
+Caltech, and future development of this fork will occur as a personal project.
+
+### Changed
+
+- SPICE kernels were removed for the respository, and now automatically download on
+  first use.
+
 ## [v1.0.8]
 
 ### Added
@@ -407,6 +418,8 @@ Initial Release
 
 
 [Unreleased]: https://github.com/dahlend/kete/tree/main
+[1.1.0]: https://github.com/dahlend/kete/releases/tag/v1.1.0
+[1.0.8]: https://github.com/dahlend/kete/releases/tag/v1.0.8
 [1.0.7]: https://github.com/dahlend/kete/releases/tag/v1.0.7
 [1.0.6]: https://github.com/dahlend/kete/releases/tag/v1.0.6
 [1.0.5]: https://github.com/dahlend/kete/releases/tag/v1.0.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "_core"
-version = "1.0.8"
+version = "1.1.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.0.8"
+version = "1.1.0"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "dardahlen@gmail.com"},

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kete_core"
-version = "1.0.8"
+version = "1.1.0"
 edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION

## [v1.1.0]

Announcement: Author of Kete (Dar Dahlen) has left IPAC Caltech to begin a PhD at
TU Braunschweig in Germany. Kete has been forked from the public copy maintained by
Caltech, and future development of this fork will occur as a personal project.

### Changed

- SPICE kernels were removed for the respository, and now automatically download on
  first use.