### PR TITLE
SCLK refactor to support conversion from/to sc ticks

### DIFF
--- a/src/kete/rust/lib.rs
+++ b/src/kete/rust/lib.rs
@@ -139,7 +139,9 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(spice::sclk_load_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::sclk_loaded_objects_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::sclk_reset_py, m)?)?;
-    m.add_function(wrap_pyfunction!(spice::sclk_time_from_str_py, m)?)?;
+    m.add_function(wrap_pyfunction!(spice::sclk_str_to_time_py, m)?)?;
+    m.add_function(wrap_pyfunction!(spice::sclk_tick_to_time_py, m)?)?;
+    m.add_function(wrap_pyfunction!(spice::sclk_time_to_tick_py, m)?)?;
 
     m.add_function(wrap_pyfunction!(spice::daf_header_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::obs_codes, m)?)?;

--- a/src/kete/rust/time.rs
+++ b/src/kete/rust/time.rs
@@ -60,15 +60,19 @@ impl From<Time<TDB>> for PyTime {
     }
 }
 
+impl From<PyTime> for Time<TDB> {
+    fn from(value: PyTime) -> Self {
+        value.0
+    }
+}
+
 #[pymethods]
 impl PyTime {
     /// Construct a new time object, TDB default.
     #[new]
     #[pyo3(signature = (jd, scaling="tdb"))]
     pub fn new(jd: f64, scaling: &str) -> PyResult<Self> {
-        let scaling = scaling.to_lowercase();
-
-        Ok(match scaling.as_str() {
+        Ok(match scaling.to_ascii_lowercase().as_str() {
             "tt" => PyTime(Time::<TDB>::new(jd)),
             "tdb" => PyTime(Time::<TDB>::new(jd)),
             "tcb" => PyTime(Time::<TDB>::new(jd)),

--- a/src/kete_core/src/time/mod.rs
+++ b/src/kete_core/src/time/mod.rs
@@ -33,7 +33,7 @@ use crate::prelude::{Error, KeteResult};
 /// Any conversions to a single float will by necessity result in some small accuracy
 /// loss due to the nature of the representation of numbers on computers.
 ///
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 
 pub struct Time<T: TimeScale> {
     /// Julian Date

--- a/src/kete_core/src/time/scales.rs
+++ b/src/kete_core/src/time/scales.rs
@@ -39,7 +39,7 @@ pub trait TimeScale {
 ///
 /// This is in agreement with TT up to about 1.7ms per century.
 /// This is in agreement with TCB up to 0.57ms per century.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TDB;
 
 impl TimeScale for TDB {
@@ -54,7 +54,7 @@ impl TimeScale for TDB {
 /// UTC Scaled JD time.
 ///
 /// The international standard for communicating time.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct UTC;
 
 impl TimeScale for UTC {
@@ -87,7 +87,7 @@ impl TimeScale for UTC {
 /// This is the international standard for the measurement of time.
 /// Atomic clocks around the world keep track of this time, which then gets
 /// converted to UTC time which is commonly used.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TAI;
 
 impl TimeScale for TAI {


### PR DESCRIPTION
In the pursuit of #11 we need support for conversion from space craft clock ticks to time. This adds support for those conversions.