### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v2.0.0]
 
+This version introduces significant rewrites to the rust core of kete.
+Includes complete rewrite of the internal representation of coordinate frames, a new
+internal rust class for Vectors, and how SPICE files are parsed.
+
+Unfortunately the above changes break any binary saved files which were previously
+saved by kete. Files can still be saved as binary, but the formats with the old version
+are not compatible any more.
+
+Also included in this version are quality of life changes, for example state vectors
+now expose all of the underlying orbital elements directly. Queries to services such
+as IRSA are now cached by default and will recover if the same query is issues.
 
 ### Added
 
@@ -478,6 +489,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/dahlend/kete/tree/main
+[2.0.0]: https://github.com/dahlend/kete/releases/tag/v1.1.0
 [1.1.0]: https://github.com/dahlend/kete/releases/tag/v1.1.0
 [1.0.8]: https://github.com/dahlend/kete/releases/tag/v1.0.8
 [1.0.7]: https://github.com/dahlend/kete/releases/tag/v1.0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["src/kete_core"]
 default-members = ["src/kete_core"]
 
 [workspace.package]
-version = "1.1.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "1.1.0"
+version = "2.0.0"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "dardahlen@gmail.com"},

--- a/src/kete/irsa.py
+++ b/src/kete/irsa.py
@@ -14,35 +14,35 @@ from .tap import query_tap, tap_column_info
 # rename the function to match the new location
 plot_fits_image = rename(
     plot_fits_image,
-    "1.2.0",
+    "2.0.0",
     old_name="plot_fits_image",
     additional_msg="Use `kete.plot.plot_fits_image` instead.",
 )
 
 zoom_plot = rename(
     zoom_plot,
-    "1.2.0",
+    "2.0.0",
     old_name="zoom_plot",
     additional_msg="Use `kete.plot.zoom_plot` instead.",
 )
 
 annotate_plot = rename(
     annotate_plot,
-    "1.2.0",
+    "2.0.0",
     old_name="annotate_plot",
     additional_msg="Use `kete.plot.annotate_plot` instead.",
 )
 
 query_column_data = rename(
     tap_column_info,
-    "1.2.0",
+    "2.0.0",
     old_name="query_column_data",
     additional_msg="Use `kete.tap.tap_column_info` instead.",
 )
 
 query_irsa_tap = rename(
     query_tap,
-    "1.2.0",
+    "2.0.0",
     old_name="query_irsa_tap",
     additional_msg="Use `kete.tap.query_tap` instead.",
 )

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -25,7 +25,7 @@ __all__ = [
 
 table_to_states = deprecation.rename(
     table_to_states,
-    "1.2.0",
+    "2.0.0",
     old_name="table_to_states",
     additional_msg="Use `kete.conversion.table_to_states` instead.",
 )

--- a/src/kete/wise.py
+++ b/src/kete/wise.py
@@ -618,6 +618,6 @@ def fetch_fovs(phase):
 
 fetch_WISE_fovs = rename(
     fetch_fovs,
-    "1.2.0",
+    "2.0.0",
     old_name="fetch_WISE_fovs",
 )

--- a/src/kete/ztf.py
+++ b/src/kete/ztf.py
@@ -140,7 +140,7 @@ def fetch_fovs(year: int):
 
 fetch_ztf_fovs = rename(
     fetch_fovs,
-    "1.2.0",
+    "2.0.0",
     old_name="fetch_ztf_fovs",
 )
 

--- a/src/kete_core/src/desigs.rs
+++ b/src/kete_core/src/desigs.rs
@@ -29,7 +29,10 @@ use std::fmt::Display;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::errors::{Error, KeteResult};
+use crate::{
+    errors::{Error, KeteResult},
+    spice::try_name_from_id,
+};
 
 static MPC_HEX: &str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
@@ -82,6 +85,19 @@ impl Desig {
     /// Return a full string representation of the designation, including the type.
     pub fn full_string(&self) -> String {
         format!("{:?}", self)
+    }
+
+    /// Try to convert a naif ID into a name.
+    pub fn try_naif_id_to_name(&self) -> Self {
+        if let Self::Naif(id) = self {
+            if let Some(name) = try_name_from_id(*id) {
+                Self::Name(name)
+            } else {
+                self.clone()
+            }
+        } else {
+            self.clone()
+        }
     }
 
     /// parse an MPC unpacked designation string into a [`Desig`].

--- a/src/kete_core/src/state.rs
+++ b/src/kete_core/src/state.rs
@@ -22,7 +22,6 @@ use std::fmt::Debug;
 use crate::desigs::Desig;
 use crate::errors::{Error, KeteResult};
 use crate::frames::{InertialFrame, Vector};
-use crate::spice;
 
 /// Exact State of an object.
 ///
@@ -140,13 +139,8 @@ impl<T: InertialFrame> State<T> {
     }
 
     /// Attempt to update the designation from a naif id to a name.
-    pub fn try_naif_id_to_name(&mut self) -> Option<()> {
-        if let Desig::Naif(id) = self.desig {
-            self.desig = Desig::Name(spice::try_name_from_id(id)?);
-            Some(())
-        } else {
-            None
-        }
+    pub fn try_naif_id_to_name(&mut self) {
+        self.desig = self.desig.try_naif_id_to_name();
     }
 
     /// Convert the state into a new frame.
@@ -214,7 +208,7 @@ mod tests {
             [0.0, 1.0, 0.0].into(),
             0,
         );
-        assert!(a.try_naif_id_to_name().is_some());
+        a.try_naif_id_to_name();
         assert!(a.desig == Desig::Name("mercury barycenter".into()));
         assert!(a.desig.full_string() == "Name(\"mercury barycenter\")");
         assert!(a.desig.to_string() == "mercury barycenter");


### PR DESCRIPTION

## [v2.0.0]

This version introduces significant rewrites to the rust core of kete.
Includes complete rewrite of the internal representation of coordinate frames, a new
internal rust class for Vectors, and how SPICE files are parsed.

Unfortunately the above changes break any binary saved files which were previously
saved by kete. Files can still be saved as binary, but the formats with the old version
are not compatible any more.

Also included in this version are quality of life changes, for example state vectors
now expose all of the underlying orbital elements directly. Queries to services such
as IRSA are now cached by default and will recover if the same query is issues.

### Added

- Added support for PTF fields of view for all public data. PTF operated from 2009 to
  2018, however data is only publicly available through early 2015.
- Generalized TAP queries to support queries to the Canadian Astronomy Data Centre
  (CADC).
- Added initial support for SPICE SCLK text kernels, allowing the conversion of
  spacecraft formatted time strings to `kete.Time` objects. Conversion matches cSPICE
  to near numerical precision limits.
- Added initial support for SPICE CK binary kernels, allowing conversion of instrument
  coordinate frames to equatorial frame and back.
- Exposed orbital element values on Python State objects, instead of having to convert
  the state first to an `CometaryElements` object.

### Changed

- Saving files to any binary format will no longer be guaranteed to be compatible in
  future versions. If a file is saved by a particular version of kete, it may only be
  compatible for that version.
- Restructured frames of reference throughout the core rust code. This is a significant
  breaking change, which introduces new objects into the kete_core code. The biggest
  changes are that frames of reference are now individual classes which implement a new
  traits `InertialFrame` and `NonInertialFrame`, and removes the previous Enum for
  frames. As a result of this, there is a new class `Vector<T>` which has been added as
  well, which must be of type `InertialFrame`. Numerous places throughout the code now
  use these `Vector` classes, which guarantees the reference frames are preserved
  without manually performing a check for matching frames. `State` now use reference
  frames as well, and `SimultaneousStates` and `FOV` objects now all use
  `State<Equatorial>` as the base representation of the states of the objects.
- Significant rewrite of reading SPICE files, there are now wrapper view types to the
  for SPK and PCK.
- Field of Views as downloaded from IRSA are now saved as parquet files. This enables
  them to be backward compatible if there are future changes to FOV, States, or Vector
  definitions. This is a breaking change for previously downloaded FOV files, and these
  may be deleted.
- Moved plotting tools out of `kete.irsa` into `kete.plot`.
- Generalized `kete.irsa` tools to `kete.tap`, and added cached query support. Queries
  to any TAP service are now cached by default, and re-running the query will restore
  the existing results by default.
- Moved `kete.mpc.table_to_states` into `kete.conversion.table_to_states`.
- Renamed `kete.wise.fetch_wise_fovs` to `kete.wise.fetch_fovs`.
- Renamed `kete.ztf.fetch_ztf_fovs` to `kete.ztf.fetch_fovs`.
- Moved RA/DEC string parsing to rust backend.
- Many functions in python now support passing one or a list of objects, for example,
  `kete.propagate_n_body` can now be passed single or multiple states, and will return
  the correct type back.
- Parsing and packing of MPC Designations was re-written and moved out of Python.
- Reduced threshold for hyperbolic orbits to `|ecc - 1| < 1e-4` from `1e-3`.
- Improved accuracy for Apophis example by included non-gravitational forces.

### Fixed

- Fixed support for `MPCObservation` parsing of MPC files, this regression was 
  due to upstream changes at the MPC in their formats.
- Parsing some non-gravitational forces from JPL Horizons was not correctly resolving
  parameter names, this is now fixed.