### PR TITLE
Change optical model to use Solar spectrum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+- Optical flux calculations now use the reference solar spectrum, and not the black
+  body assumption for the Sun.
+
+
 ## [v2.0.0]
 
 This version introduces significant rewrites to the rust core of kete.

--- a/src/examples/plot_flux_vs_wavelength.py
+++ b/src/examples/plot_flux_vs_wavelength.py
@@ -19,7 +19,7 @@ def flux_per_wavelength(
     solar_elong=np.radians(83),
     v_albedo=0.17,
     diameter=0.140,
-    wavelength=np.logspace(np.log10(300), np.log10(30000), 100),
+    wavelength=np.logspace(np.log10(300), np.log10(30000), 1000),
 ):
     """
     Calculate the flux as a function of wavelength.

--- a/src/kete/rust/flux/reflected.rs
+++ b/src/kete/rust/flux/reflected.rs
@@ -1,7 +1,7 @@
 use crate::{frame::PyFrames, vector::VectorLike};
 use kete_core::constants;
-use kete_core::flux::hg_phase_curve_correction;
 use kete_core::flux::HGParams;
+use kete_core::flux::hg_phase_curve_correction;
 use pyo3::pyfunction;
 
 /// This computes the phase curve correction in the IAU format.
@@ -29,8 +29,9 @@ pub fn hg_phase_curve_correction_py(g_param: f64, phase_angle: f64) -> f64 {
 /// This assumes that the object is an ideal disk facing the sun and applies the IAU
 /// correction curve to the reflected light, returning units of Jy per unit frequency.
 ///
-/// This treats the sun as a flat black body disk, which is a good approximation as long
-/// as the object is several solar radii away.
+/// This treats the sun as an infinitesimal point source, which is a good approximation
+/// as long as the object is several solar radii away. This uses a reference solar
+/// spectrum at the specified wavelength.
 ///
 /// Either `h_mag` or `diameter` must be provided, but only 1 is strictly required.
 /// The other will be computed if not provided.

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -1,4 +1,4 @@
-use super::sun::solar_flux_black_body;
+use super::solar_flux;
 use crate::{
     constants::{AU_KM, C_V},
     prelude::{Error, KeteResult},
@@ -274,13 +274,11 @@ impl HGParams {
     ///
     /// This flux calculation accepts a wavelength, which can be used to estimate the
     /// flux outside of band definition which is implicit in the HG system when querying the
-    /// Minor Planet Center or JPL Horizons. The assumptions made here are that the Sun is an
-    /// ideal black body, and the the phase correction curve defined by the G parameter is
-    /// valid for the wavelength provided. Neither of these are precisely true, but are a
-    /// good first order approximation.
+    /// Minor Planet Center or JPL Horizons. The assumptions made here is that the phase
+    /// correction curve defined by the G parameter is valid for the wavelength provided.
     ///
-    /// This treats the sun as a flat black body disk, which is a good approximation as long
-    /// as the object is several solar radii away.
+    /// This treats the sun as an infinitesimal point source, producing the correct reference
+    /// spectrum of the sun as defined by [`solar_flux`] at the wavelength specified.
     ///
     /// The IAU model is not technically defined above 120 degrees phase, however this will
     /// continue to return values fit to the model until 160 degrees. Phases larger than
@@ -311,7 +309,7 @@ impl HGParams {
         let diameter = self.diam()?;
 
         // Jy
-        let flux_at_object = solar_flux_black_body(sun2obj.norm(), wavelength);
+        let flux_at_object = solar_flux(sun2obj.norm(), wavelength)?;
 
         // total Flux from the object, treating the object as a lambertian sphere
         // Jy * km^2


### PR DESCRIPTION
Change the optical reflection model to use the actual solar spectrum instead of the black body approximation. This does not impact the HG system at all, its just for the more complex optical reflection models for the non-V band spectrum.

![image](https://github.com/user-attachments/assets/7536046e-fa55-4dfb-b6a6-894bcf59e5b7)


I have been avoiding this one for a long time, as this change may require a revisit for WISE color-correction calculations. I believe the original WISE color corrections were calculated assuming a black body.