### PR TITLE
Move designation lookups to rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+- Moved name lookups for SPICE and Observatory codes to the rust backend. This speeds
+  up lookup of states in python by about a factor of 2.
+
+### Fixed
+
+- `HorizonsProperties` sampling and queries to horizons is more robust to unexpected
+  responses from the Horizons service.
+
 ## [v2.0.0]
 
 This version introduces significant rewrites to the rust core of kete.

--- a/src/kete/horizons.py
+++ b/src/kete/horizons.py
@@ -313,6 +313,10 @@ def _sample(self, n_samples):
     n_samples :
         The number of samples to take of the covariance.
     """
+    if self.covariance is None:
+        raise ValueError(
+            "This object does not have a covariance matrix, cannot sample from it."
+        )
     matrix = self.covariance.cov_matrix
     epoch = Time(self.covariance.epoch, scaling="utc").jd
     samples = generate_sample_from_cov(n_samples, matrix)

--- a/src/kete/horizons.py
+++ b/src/kete/horizons.py
@@ -9,6 +9,7 @@ import json
 import os
 from functools import lru_cache
 from typing import Optional, Union
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -260,8 +261,10 @@ def _json(self) -> dict:
     return _fetch_json(self.desig, update_cache=False)
 
 
-def _nongrav_params(self) -> dict:
-    # default parameters used by jpl horizons for their non-grav models.
+def _default_nongrav_params() -> dict:
+    """default parameters used by jpl horizons for their non-grav models."""
+    # This exists so that we dont have to worry about a global variable being
+    # updated by accident.
     params = {
         "a1": 0.0,
         "a2": 0.0,
@@ -273,16 +276,6 @@ def _nongrav_params(self) -> dict:
         "k": 4.6142,
         "dt": 0.0,
     }
-
-    orbit = self.json["orbit"]
-    if "model_pars" not in orbit:
-        return params
-
-    for vals in orbit["model_pars"]:
-        param_name = vals["name"].lower()
-        if param_name not in _PARAM_MAP:
-            raise ValueError("Unknown non-grav values: ", vals)
-        params[_PARAM_MAP[param_name]] = float(vals["value"])
     return params
 
 
@@ -291,7 +284,19 @@ def _nongrav(self) -> NonGravModel:
     """
     The non-gravitational forces model from the values returned from horizons.
     """
-    params = _nongrav_params(self)
+    orbit = self.json["orbit"]
+    if "model_pars" not in orbit:
+        return None
+    model_pars_json = orbit["model_pars"]
+
+    params = _default_nongrav_params()
+    for vals in model_pars_json:
+        param_name = vals["name"].lower()
+        if param_name not in _PARAM_MAP:
+            warn(f"Unknown non-grav values: {vals}", stacklevel=2)
+            continue
+        params[_PARAM_MAP[param_name]] = float(vals["value"])
+
     return NonGravModel.new_comet(**params)
 
 
@@ -321,14 +326,32 @@ def _sample(self, n_samples):
         "peri_time",
     ]
 
+    orbit = self.json["orbit"]
+    has_nongrav = "model_pars" in orbit
+    has_warned = False
+
     states = []
     non_gravs = []
     for sample in samples:
         names, vals = zip(*self.covariance.params)
-        params = dict(zip(names, np.array(vals) + sample))
-        elem_params = {x: params.pop(x) for x in elem_keywords}
+        sample_params = dict(zip(names, np.array(vals) + sample))
+        elem_params = {x: sample_params.pop(x) for x in elem_keywords}
         state = CometElements(self.desig, epoch, **elem_params).state
-        non_grav = NonGravModel.new_comet(**params)
+        if has_nongrav:
+            params = _default_nongrav_params()
+            for key, value in sample_params.items():
+                if key in _PARAM_MAP:
+                    params[_PARAM_MAP[key]] = value
+                elif not has_warned:
+                    warn(
+                        f"Unknown non-grav parameter {key} in sample, "
+                        "this may cause issues with the non-grav model.",
+                        stacklevel=2,
+                    )
+                    has_warned = True
+            non_grav = NonGravModel.new_comet(**params)
+        else:
+            non_grav = None
         states.append(state)
         non_gravs.append(non_grav)
 

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -7,8 +7,8 @@ from functools import lru_cache
 import numpy as np
 import pandas as pd
 
-from . import _core, constants, conversion, deprecation
-from ._core import pack_designation, unpack_designation
+from . import constants, conversion, deprecation
+from ._core import pack_designation, unpack_designation, find_obs_code
 from .cache import download_json
 from .conversion import table_to_states
 from .time import Time
@@ -31,40 +31,6 @@ table_to_states = deprecation.rename(
 )
 
 logger = logging.getLogger(__name__)
-
-
-@lru_cache
-def find_obs_code(name: str):
-    """
-    Search known observatory codes, if a single matching observatory is found, this will
-    return the [lat, lon, altitude, description, obs code] in degrees and km as
-    appropriate.
-
-    >>> kete.mpc.find_obs_code("Palomar Mountain")
-    [33.35411714, -116.86254, 1.69606288, 'Palomar Mountain', '675']
-
-    Parameters
-    ----------
-    name :
-        Name of the observatory, this can be a partial name, or obs code.
-    """
-    codes = _core.observatory_codes()
-    found = []
-    name_lower = name.lower().strip()
-    for obs in codes:
-        obs = [float(np.around(x, 8)) if isinstance(x, float) else x for x in obs]
-        if name_lower in obs[3].lower() or name_lower in obs[4].lower():
-            # If an exact match, return early.
-            if name == obs[3]:
-                return obs
-            found.append(obs)
-    if len(found) == 1:
-        return found[0]
-    elif len(found) == 0:
-        raise ValueError("Failed to find matching observatory code.")
-    else:
-        found_str = "\n".join([f"{x[3]} - {x[4]}" for x in found])
-        raise ValueError(f"Found multiple codes: \n{found_str}")
 
 
 @lru_cache

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from . import constants, conversion, deprecation
-from ._core import pack_designation, unpack_designation, find_obs_code
+from ._core import find_obs_code, pack_designation, unpack_designation
 from .cache import download_json
 from .conversion import table_to_states
 from .time import Time

--- a/src/kete/rust/desigs.rs
+++ b/src/kete/rust/desigs.rs
@@ -1,6 +1,7 @@
 //! Interface for Minor Planet Center (MPC) utilities
 //!
 //!
+use kete_core::desigs::Desig;
 use pyo3::prelude::*;
 
 /// Accepts either a unpacked provisional designation or permanent designation and
@@ -20,7 +21,7 @@ use pyo3::prelude::*;
 #[pyfunction]
 #[pyo3(name = "pack_designation")]
 pub fn pack_designation_py(desig: String) -> PyResult<String> {
-    let packed = kete_core::desigs::Desig::parse_mpc_designation(desig.trim())?;
+    let packed = Desig::parse_mpc_designation(desig.trim())?;
     Ok(packed.try_pack()?)
 }
 
@@ -40,6 +41,88 @@ pub fn pack_designation_py(desig: String) -> PyResult<String> {
 #[pyfunction]
 #[pyo3(name = "unpack_designation")]
 pub fn unpack_designation_py(desig: String) -> PyResult<String> {
-    let packed = kete_core::desigs::Desig::parse_mpc_packed_designation(desig.trim())?;
+    let packed = Desig::parse_mpc_packed_designation(desig.trim())?;
     Ok(packed.to_string())
+}
+
+/// Given the provided partial name or integer, find the full name contained within
+/// the loaded SPICE kernels.
+///
+/// >>> kete.spice.name_lookup("jupi")
+/// ('jupiter barycenter', 5)
+///
+/// >>> kete.spice.name_lookup(10)
+/// ('sun', 10)
+///
+/// If there are multiple names, but an exact match, the exact match is returned. In
+/// the case of ``Earth``, there is also ``Earth Barycenter``, but asking for Earth
+/// will return the exact match. Putting ``eart`` will raise an exception as there
+/// are 2 partial matches.
+///
+/// >>> kete.spice.name_lookup("Earth")
+/// ('earth', 399)
+///
+/// >>> kete.spice.name_lookup("Earth b")
+/// ('earth barycenter', 3)
+///
+/// Parameters
+/// ----------
+/// name :
+///     Name, partial name, or integer id value of the object.
+///
+/// Returns
+/// -------
+/// tuple :
+///     Two elements in the tuple, the full name and the integer id value.
+#[pyfunction]
+#[pyo3(name = "name_lookup")]
+pub fn naif_name_lookup_py(name: NaifIDLike) -> PyResult<(String, i32)> {
+    Ok(name.try_into()?)
+}
+
+/// A type that can be used to represent a NAIF ID.
+/// This is for polymorphic use in functions that can accept either a string or an
+/// integer as a NAIF ID.
+#[derive(Debug, Clone, PartialEq, Eq, FromPyObject, IntoPyObject)]
+pub enum NaifIDLike {
+    /// A string that can be converted to a NAIF ID.
+    String(String),
+
+    /// An integer that is a NAIF ID.
+    Int(i32),
+}
+
+impl From<NaifIDLike> for Desig {
+    fn from(value: NaifIDLike) -> Self {
+        match value {
+            NaifIDLike::String(s) => Desig::Name(s),
+            NaifIDLike::Int(i) => Desig::Naif(i).try_naif_id_to_name(),
+        }
+    }
+}
+
+impl TryInto<(String, i32)> for NaifIDLike {
+    type Error = kete_core::prelude::Error;
+
+    #[inline(always)]
+    fn try_into(self) -> Result<(String, i32), Self::Error> {
+        match self {
+            NaifIDLike::String(s) => {
+                if s.chars().all(|c| c.is_ascii_digit()) {
+                    // If the string is all digits, convert it directly to an integer.
+                    if let Ok(id) = s.parse::<i32>() {
+                        return Ok((kete_core::spice::try_name_from_id(id).unwrap_or(s), id));
+                    }
+                }
+                // try the spk cache
+                let mut spk = kete_core::spice::LOADED_SPK.write().unwrap();
+                let id = spk.try_id_from_name(&s)?;
+                Ok((id.name, id.id))
+            }
+            NaifIDLike::Int(i) => Ok((
+                kete_core::spice::try_name_from_id(i).unwrap_or(i.to_string()),
+                i,
+            )),
+        }
+    }
 }

--- a/src/kete/rust/lib.rs
+++ b/src/kete/rust/lib.rs
@@ -127,7 +127,6 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(spice::spk_state_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::spk_raw_state_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::spk_reset_py, m)?)?;
-    m.add_function(wrap_pyfunction!(spice::spk_get_name_from_id_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::spk_available_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::spk_load_cache_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::spk_load_core_py, m)?)?;
@@ -170,6 +169,7 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(desigs::unpack_designation_py, m)?)?;
     m.add_function(wrap_pyfunction!(desigs::pack_designation_py, m)?)?;
+    m.add_function(wrap_pyfunction!(desigs::naif_name_lookup_py, m)?)?;
 
     Ok(())
 }

--- a/src/kete/rust/lib.rs
+++ b/src/kete/rust/lib.rs
@@ -154,6 +154,7 @@ fn _core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(spice::daf_header_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(spice::obs_codes, m)?)?;
+    m.add_function(wrap_pyfunction!(spice::find_obs_code_py, m)?)?;
 
     m.add_function(wrap_pyfunction!(state_transition::compute_stm_py, m)?)?;
 

--- a/src/kete/rust/spice/mod.rs
+++ b/src/kete/rust/spice/mod.rs
@@ -7,11 +7,12 @@ mod spk;
 
 pub use ck::*;
 pub use daf::*;
+use kete_core::spice::try_obs_code_from_name;
 pub use pck::*;
 pub use sclk::*;
 pub use spk::*;
 
-use pyo3::pyfunction;
+use pyo3::{PyResult, pyfunction};
 
 /// Return a list of MPC observatory codes, along with the latitude, longitude (deg),
 /// altitude (m above the WGS84 surface), and name.
@@ -29,4 +30,55 @@ pub fn obs_codes() -> Vec<(f64, f64, f64, String, String)> {
         ))
     }
     codes
+}
+
+/// Search known observatory codes, if a single matching observatory is found, this
+/// will return the [lat, lon, altitude, description, obs code] in degrees and km as
+/// appropriate.
+///
+/// >>> kete.mpc.find_obs_code("Palomar Mountain")
+/// (33.35411714, -116.86254, 1.69606, 'Palomar Mountain', '675')
+///
+/// Parameters
+/// ----------
+/// name :
+///     Name of the observatory, this can be a partial name, or obs code.
+#[pyfunction]
+#[pyo3(name = "find_obs_code")]
+pub fn find_obs_code_py(name: &str) -> PyResult<(f64, f64, f64, String, String)> {
+    let obs_codes = try_obs_code_from_name(name);
+
+    if obs_codes.is_empty() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "No observatory codes found for the given name.",
+        ));
+    } else if obs_codes.len() > 1 {
+        // if there is an exact match, return that one
+        if let Some(exact_match) = obs_codes.iter().find(|obs| obs.name == name) {
+            return Ok((
+                (exact_match.lat * 1e8).round() / 1e8 + 0.0,
+                (exact_match.lon * 1e8).round() / 1e8 + 0.0,
+                (exact_match.altitude * 1e5).round() / 1e5 + 0.0,
+                exact_match.name.clone(),
+                exact_match.code.to_string(),
+            ));
+        }
+
+        let possible_matches = obs_codes
+            .iter()
+            .map(|obs| format!("{} - {}", obs.name.clone(), obs.code))
+            .collect::<Vec<_>>()
+            .join(",\n");
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Multiple observatory codes found for the given name:\n{}",
+            possible_matches
+        )));
+    }
+    let obs_code = obs_codes[0].clone();
+
+    let lat = (obs_code.lat * 1e8).round() / 1e8 + 0.0;
+    let lon = (obs_code.lon * 1e8).round() / 1e8 + 0.0;
+    let altitude = (obs_code.altitude * 1e5).round() / 1e5 + 0.0;
+
+    Ok((lat, lon, altitude, obs_code.name, obs_code.code.to_string()))
 }

--- a/src/kete/rust/vector.rs
+++ b/src/kete/rust/vector.rs
@@ -2,14 +2,12 @@
 use kete_core::frames::Vector;
 use kete_core::util::Degrees;
 use pyo3::basic::CompareOp;
-use pyo3::exceptions;
-use pyo3::exceptions::PyNotImplementedError;
+use pyo3::exceptions::{PyIndexError, PyNotImplementedError};
 use std::f64::consts::FRAC_PI_2;
 
 use crate::frame::*;
 use kete_core::prelude::*;
 use pyo3::prelude::*;
-use pyo3::PyResult;
 
 /// Vector class which is a vector along with a reference frame.
 ///
@@ -318,6 +316,7 @@ impl PyVector {
     pub fn __repr__(&self) -> String {
         // 1e-12 AU is about 15cm, this seems like a reasonable printing resolution
         let raw = self.raw();
+        // adding 0.0 will flip the sign of -0.0 to 0.0
         let x = (raw[0] * 1e12).round() / 1e12 + 0.0;
         let y = (raw[1] * 1e12).round() / 1e12 + 0.0;
         let z = (raw[2] * 1e12).round() / 1e12 + 0.0;
@@ -365,7 +364,7 @@ impl PyVector {
     #[allow(missing_docs)]
     pub fn __getitem__(&self, idx: usize) -> PyResult<f64> {
         if idx >= 3 {
-            return Err(PyErr::new::<exceptions::PyIndexError, _>(""));
+            return Err(PyErr::new::<PyIndexError, _>("Index out of bounds"));
         }
         Ok(self.raw()[idx])
     }

--- a/src/kete/spice.py
+++ b/src/kete/spice.py
@@ -9,12 +9,12 @@ import requests
 
 from . import _core
 from ._core import (
+    get_state,
     instrument_equatorial_to_frame,
     instrument_frame_to_equatorial,
-    state_to_earth_pos,
-    name_lookup,
-    get_state,
     loaded_objects,
+    name_lookup,
+    state_to_earth_pos,
 )
 from .cache import cache_path, download_file
 from .constants import AU_KM

--- a/src/kete_core/src/spice/mod.rs
+++ b/src/kete_core/src/spice/mod.rs
@@ -16,8 +16,8 @@ pub(crate) mod sclk;
 
 pub use ck::{CkCollection, LOADED_CK};
 pub use daf::{CkArray, DAFType, DafArray, DafFile, PckArray, SpkArray};
-pub use naif_ids::try_name_from_id;
-pub use obs_codes::{OBS_CODES, ObsCode};
+pub use naif_ids::{NaifId, naif_ids_from_name, try_name_from_id};
+pub use obs_codes::{OBS_CODES, ObsCode, try_obs_code_from_name};
 pub use pck::{LOADED_PCK, PckCollection};
 pub use sclk::{LOADED_SCLK, SclkCollection};
 pub use spk::{LOADED_SPK, SpkCollection};

--- a/src/kete_core/src/spice/naif_ids.rs
+++ b/src/kete_core/src/spice/naif_ids.rs
@@ -5,17 +5,18 @@ use lazy_static::lazy_static;
 use serde::Deserialize;
 
 use crate::prelude::{Error, KeteResult};
+use crate::util::partial_str_match;
 use std::str;
 use std::str::FromStr;
 
 /// NAIF ID information
-#[derive(Debug, Deserialize)]
-struct NaifId {
+#[derive(Debug, Deserialize, Clone)]
+pub struct NaifId {
     /// NAIF id
-    id: i32,
+    pub id: i32,
 
     /// name of the object
-    name: String,
+    pub name: String,
 }
 
 impl FromStr for NaifId {
@@ -51,4 +52,19 @@ pub fn try_name_from_id(id: i32) -> Option<String> {
         }
     }
     None
+}
+
+/// Try to find a NAIF id from a name.
+///
+/// This will return all matching IDs for the given name.
+///
+/// This does a partial string match, case insensitive.
+pub fn naif_ids_from_name(name: &str) -> Vec<NaifId> {
+    // this should be re-written to be simpler
+    let desigs: Vec<String> = NAIF_IDS.iter().map(|n| n.name.to_lowercase()).collect();
+    let desigs: Vec<&str> = desigs.iter().map(|x| x.as_str()).collect();
+    partial_str_match(&name.to_lowercase(), &desigs)
+        .into_iter()
+        .map(|(i, _)| NAIF_IDS[i].clone())
+        .collect()
 }

--- a/src/kete_core/src/state.rs
+++ b/src/kete_core/src/state.rs
@@ -140,7 +140,7 @@ impl<T: InertialFrame> State<T> {
 
     /// Attempt to update the designation from a naif id to a name.
     pub fn try_naif_id_to_name(&mut self) {
-        self.desig = self.desig.try_naif_id_to_name();
+        self.desig = self.desig.clone().try_naif_id_to_name();
     }
 
     /// Convert the state into a new frame.

--- a/src/kete_core/src/util.rs
+++ b/src/kete_core/src/util.rs
@@ -268,6 +268,22 @@ fn parse_str_to_floats(text: &str) -> KeteResult<(f64, f64, f64)> {
     Ok((h, m, s))
 }
 
+/// Find the entire provided string in a collection of strings which may contain
+/// partial matches.
+///
+/// Case insensitive search is performed.
+///
+/// Return all possible matches along with their indices.
+pub fn partial_str_match<'a>(needle: &str, haystack: &'a [&'a str]) -> Vec<(usize, &'a str)> {
+    let needle = needle.trim().to_lowercase();
+    haystack
+        .iter()
+        .enumerate()
+        .filter(|&(_, &hay)| hay.to_lowercase().contains(&needle))
+        .map(|(i, &hay)| (i, hay))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tests/test_spice.py
+++ b/src/tests/test_spice.py
@@ -57,13 +57,13 @@ class TestSpice:
         )
 
     def test_name_lookup(self):
-        assert spice.name_lookup("jupi") == ("jupiter barycenter", 5)
-        assert spice.name_lookup(0) == ("ssb", 0)
+        assert spice.name_lookup("jupiter b") == ("jupiter barycenter", 5)
+        assert spice.name_lookup(0) == ("solar system barycenter", 0)
 
-        with pytest.raises(ValueError, match="Multiple objects"):
+        with pytest.raises(ValueError, match="Multiple NAIF"):
             spice.name_lookup("ear")
 
-        with pytest.raises(ValueError, match="No loaded objects"):
+        with pytest.raises(ValueError, match="No NAIF ID found for"):
             spice.name_lookup("banana")
 
     def test_loaded_info(self):


### PR DESCRIPTION
This partial name matches for both NAIF ids and MPC Observatory codes have been moved to rust. These retain the same cached lookup design as the original python.

Typical speedup appears to be about a factor of 2 for spice queries.