### PR TITLE
Add 15 seconds to ZTF fovs

### DIFF
--- a/src/kete/plot.py
+++ b/src/kete/plot.py
@@ -64,7 +64,7 @@ def plot_fits_image(fit, percentiles=(0.1, 99.95), power_stretch=0.5, cmap="gray
     ax = fig.add_subplot(rows, cols, start + 1, projection=wcs)
     ax.set_aspect("equal", adjustable="box")
     fig.axes[start] = ax
-    
+
     stretch = LinearStretch() if power_stretch == 1 else PowerDistStretch(power_stretch)
 
     if percentiles is None:

--- a/src/kete/ptf.py
+++ b/src/kete/ptf.py
@@ -124,7 +124,7 @@ def fetch_fovs(year: int):
         fov = PtfField(value)
         final_fovs.append(fov)
 
-    # finally save and return the result
+    # return the result
     fov_list = FOVList(final_fovs)
     return fov_list
 

--- a/src/kete/ztf.py
+++ b/src/kete/ztf.py
@@ -90,7 +90,8 @@ def fetch_fovs(year: int):
         )
         irsa_query.to_parquet(filename, index=False)
 
-    jds = [Time.from_iso(x + ":00").jd for x in irsa_query["obsdate"]]
+    offset = 15 / 24 / 60 / 60
+    jds = [Time.from_iso(x + ":00").jd + offset for x in irsa_query["obsdate"]]
     obs_info = find_obs_code("ZTF")
 
     # ZTF fields are made up of up to 64 individual CCD quads, here we first construct


### PR DESCRIPTION
Time in the fov sql database is recorded from the beginning of the observation, this sets it to the middle of the observation