### PR TITLE
Allow poorly formatted SPK files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/dahlend/kete"
 kete_core = { version = "*", path = "src/kete_core", features=["pyo3", "polars"]}
 pyo3 = { version =  "^0.25.0", features = ["extension-module", "abi3-py39"] }
 serde = { version = "^1.0.203", features = ["derive"] }
-nalgebra = {version = "^0.33.0"}
+nalgebra = {version = "^0.33.0", features = ["rayon"]}
 itertools = "^0.14.0"
 rayon = "^1.10.0"
 sgp4 = "2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = ["astropy>=5.3.4",
 homepage = "https://github.com/dahlend/kete"
 
 [build-system]
-requires = ["maturin>=1.0",
+requires = ["maturin>=1.9",
             "wheel",
             ]
 build-backend = "maturin"

--- a/src/kete/rust/frame.rs
+++ b/src/kete/rust/frame.rs
@@ -239,5 +239,5 @@ pub fn approx_earth_pos_to_ecliptic_py(
         desig,
     )?
     .into();
-    state.change_center(10)
+    state.change_center(crate::desigs::NaifIDLike::Int(10))
 }

--- a/src/kete/rust/horizons.rs
+++ b/src/kete/rust/horizons.rs
@@ -155,7 +155,7 @@ impl HorizonsProperties {
         fn cleanup<T: Debug>(opt: Option<T>) -> String {
             match opt {
                 None => "None".into(),
-                Some(val) => format!("{:?}", val),
+                Some(val) => format!("{val:?}"),
             }
         }
 

--- a/src/kete/rust/kepler.rs
+++ b/src/kete/rust/kepler.rs
@@ -83,7 +83,7 @@ pub fn propagation_kepler_py(
             let center = state.center_id();
             let frame = state.frame();
 
-            let Some(state) = state.change_center(10).ok() else {
+            let Some(state) = state.change_center(crate::desigs::NaifIDLike::Int(10)).ok() else {
                 let nan_state: PyState =
                     State::<Ecliptic>::new_nan(state.raw.desig.clone(), jd, center).into();
                 return nan_state.change_frame(frame);
@@ -108,7 +108,7 @@ pub fn propagation_kepler_py(
 
             new_pystate
                 .change_frame(frame)
-                .change_center(center)
+                .change_center(crate::desigs::NaifIDLike::Int(center))
                 .unwrap_or(
                     State::<Ecliptic>::new_nan(state.raw.desig, jd, state.raw.center_id).into(),
                 )

--- a/src/kete/rust/nongrav.rs
+++ b/src/kete/rust/nongrav.rs
@@ -210,7 +210,7 @@ impl PyNonGravModel {
     pub fn __repr__(&self) -> String {
         match self.0 {
             NonGravModel::Dust { beta } => {
-                format!("kete.propagation.NonGravModel.new_dust(beta={:?})", beta)
+                format!("kete.propagation.NonGravModel.new_dust(beta={beta:?})")
             }
             NonGravModel::JplComet {
                 a1,
@@ -223,8 +223,7 @@ impl PyNonGravModel {
                 k,
                 dt,
             } => format!(
-                "kete.propagation.NonGravModel.new_comet(a1={:?}, a2={:?}, a3={:?}, alpha={:?}, r_0={:?}, m={:?}, n={:?}, k={:?}, dt={:?})",
-                a1, a2, a3, alpha, r_0, m, n, k, dt
+                "kete.propagation.NonGravModel.new_comet(a1={a1:?}, a2={a2:?}, a3={a3:?}, alpha={alpha:?}, r_0={r_0:?}, m={m:?}, n={n:?}, k={k:?}, dt={dt:?})",
             ),
         }
     }

--- a/src/kete/rust/simult_states.rs
+++ b/src/kete/rust/simult_states.rs
@@ -257,10 +257,7 @@ impl PySimultaneousStates {
             None => "None".into(),
             Some(f) => f.__repr__(),
         };
-        format!(
-            "SimultaneousStates(states=<{} States>, fov={})",
-            n_states, fov_str
-        )
+        format!("SimultaneousStates(states=<{n_states} States>, fov={fov_str})",)
     }
 
     /// Save a list to a binary file.

--- a/src/kete/rust/spice/ck.rs
+++ b/src/kete/rust/spice/ck.rs
@@ -15,7 +15,7 @@ pub fn ck_load_py(filenames: Vec<String>) -> PyResult<()> {
     for filename in filenames.iter() {
         let load = (*singleton).load_file(filename);
         if let Err(err) = load {
-            eprintln!("{} failed to load. {}", filename, err);
+            eprintln!("{filename} failed to load. {err}");
         }
     }
     Ok(())

--- a/src/kete/rust/spice/mod.rs
+++ b/src/kete/rust/spice/mod.rs
@@ -70,8 +70,7 @@ pub fn find_obs_code_py(name: &str) -> PyResult<(f64, f64, f64, String, String)>
             .collect::<Vec<_>>()
             .join(",\n");
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
-            "Multiple observatory codes found for the given name:\n{}",
-            possible_matches
+            "Multiple observatory codes found for the given name:\n{possible_matches}",
         )));
     }
     let obs_code = obs_codes[0].clone();

--- a/src/kete/rust/spice/pck.rs
+++ b/src/kete/rust/spice/pck.rs
@@ -15,7 +15,7 @@ pub fn pck_load_py(filenames: Vec<String>) -> PyResult<()> {
     for filename in filenames.iter() {
         let load = (*singleton).load_file(filename);
         if let Err(err) = load {
-            eprintln!("{} failed to load. {}", filename, err);
+            eprintln!("{filename} failed to load. {err}");
         }
     }
     Ok(())
@@ -86,7 +86,9 @@ pub fn pck_earth_frame_py(
 #[pyo3(name = "state_to_earth_pos")]
 pub fn pck_state_to_earth(state: PyState) -> PyResult<(f64, f64, f64)> {
     let pcks = LOADED_PCK.try_read().unwrap();
-    let state = state.change_center(399)?.raw;
+    let state = state
+        .change_center(crate::desigs::NaifIDLike::Int(399))?
+        .raw;
     let frame = pcks.try_get_orientation(3000, state.jd)?;
 
     let (pos, _) = frame.from_equatorial(state.pos.into(), state.vel.into())?;

--- a/src/kete/rust/spice/sclk.rs
+++ b/src/kete/rust/spice/sclk.rs
@@ -11,7 +11,7 @@ pub fn sclk_load_py(filenames: Vec<String>) -> PyResult<()> {
     for filename in filenames.iter() {
         let load = (*singleton).load_file(filename);
         if let Err(err) = load {
-            eprintln!("{} failed to load. {}", filename, err);
+            eprintln!("{filename} failed to load. {err}");
         }
     }
     Ok(())

--- a/src/kete/rust/state.rs
+++ b/src/kete/rust/state.rs
@@ -96,10 +96,11 @@ impl PyState {
     /// Change the center ID of the state from the current state to the target state.
     ///
     /// If the desired state is not a known NAIF id this will raise an exception.
-    pub fn change_center(&self, naif_id: i32) -> PyResult<Self> {
+    pub fn change_center(&self, naif_id: NaifIDLike) -> PyResult<Self> {
+        let naif_id: (String, i32) = naif_id.try_into()?;
         let mut state = self.raw.clone();
         let spk = LOADED_SPK.try_read().unwrap();
-        spk.try_change_center(&mut state, naif_id)?;
+        spk.try_change_center(&mut state, naif_id.1)?;
         Ok(Self {
             raw: state,
             frame: self.frame,

--- a/src/kete/rust/time.rs
+++ b/src/kete/rust/time.rs
@@ -76,8 +76,7 @@ impl PyTime {
             "tai" => PyTime(Time::<TAI>::new(jd).tdb()),
             "utc" => PyTime(Time::<UTC>::new(jd).tdb()),
             s => Err(Error::ValueError(format!(
-                "Scaling of type ({:?}) is not supported, must be one of: 'tt', 'tdb', 'tcb', 'tai', 'utc'",
-                s
+                "Scaling of type ({s}) is not supported, must be one of: 'tt', 'tdb', 'tcb', 'tai', 'utc'",
             )))?,
         })
     }
@@ -102,8 +101,7 @@ impl PyTime {
             "tai" => PyTime(Time::<TAI>::from_mjd(mjd).tdb()),
             "utc" => PyTime(Time::<UTC>::from_mjd(mjd).tdb()),
             s => Err(Error::ValueError(format!(
-                "Scaling of type ({:?}) is not supported, must be one of: 'tt', 'tdb', 'tai', 'utc'",
-                s
+                "Scaling of type ({s}) is not supported, must be one of: 'tt', 'tdb', 'tai', 'utc'",
             )))?,
         })
     }

--- a/src/kete/rust/utils.rs
+++ b/src/kete/rust/utils.rs
@@ -80,8 +80,7 @@ pub fn dec_dms_to_degrees_py(py: Python<'_>, dec: MaybeVec<String>) -> PyResult<
             })
             .map_err(|_| {
                 PyErr::new::<PyValueError, _>(format!(
-                    "Invalid declination format: '{}'. Expected 'degrees arcminutes arcseconds'.",
-                    dms
+                    "Invalid declination format: '{dms}'. Expected 'degrees arcminutes arcseconds'.",
                 ))
             })?;
     }
@@ -112,8 +111,7 @@ pub fn ra_hms_to_degrees_py(py: Python<'_>, ra: MaybeVec<String>) -> PyResult<Py
             })
             .map_err(|_| {
                 PyErr::new::<PyValueError, _>(format!(
-                    "Invalid right ascension format: '{}'. Expected 'hours minutes seconds'.",
-                    hms
+                    "Invalid right ascension format: '{hms}'. Expected 'hours minutes seconds'.",
                 ))
             })?;
     }

--- a/src/kete_core/Cargo.toml
+++ b/src/kete_core/Cargo.toml
@@ -24,7 +24,7 @@ crossbeam = "^0.8.4"
 directories = "^6.0"
 itertools = "^0.14.0"
 kdtree = "^0.7.0"
-nalgebra = {version = "^0.33.0"}
+nalgebra = {version = "^0.33.0", features = ["rayon"]}
 nom = "8.0.0"
 polars = {version = "0.48.1", optional=true, features=["parquet", "polars-io"]}
 pathfinding = "^4.10.0"

--- a/src/kete_core/src/cache.rs
+++ b/src/kete_core/src/cache.rs
@@ -27,8 +27,7 @@ pub fn cache_dir() -> KeteResult<PathBuf> {
             let path = PathBuf::from(env_path);
             if !path.exists() {
                 return Err(Error::IOError(format!(
-                    "KETE_CACHE_DIR does not exist: {:?}",
-                    path
+                    "KETE_CACHE_DIR does not exist: {path:?}"
                 )));
             }
             Ok(path)

--- a/src/kete_core/src/constants/gravity.rs
+++ b/src/kete_core/src/constants/gravity.rs
@@ -75,8 +75,7 @@ impl FromStr for GravParams {
         let radius = iter.next().unwrap_or("0.0");
         if naif_id.is_none() || mass.is_none() {
             return Err(Error::IOError(format!(
-                "GravParams row incorrectly formatted. {}",
-                row
+                "GravParams row incorrectly formatted. {row}",
             )));
         }
         let mass: f64 = mass.unwrap().parse()?;
@@ -143,7 +142,7 @@ pub fn register_mass(naif_id: i32) {
         params.register();
         return;
     }
-    panic!("Failed to find mass for NAIF ID {}", naif_id);
+    panic!("Failed to find mass for NAIF ID {naif_id}");
 }
 
 /// List the massive objects in the extended list of objects to be used during orbit propagation.

--- a/src/kete_core/src/desigs.rs
+++ b/src/kete_core/src/desigs.rs
@@ -84,7 +84,7 @@ pub enum Desig {
 impl Desig {
     /// Return a full string representation of the designation, including the type.
     pub fn full_string(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     /// Try to convert a naif ID into a name.
@@ -364,21 +364,18 @@ impl Desig {
                 "Cannot pack an empty designation".to_string(),
             )),
             Self::Name(s) => Err(Error::ValueError(format!(
-                "Cannot pack a name as a designation: {}",
-                s
+                "Cannot pack a name as a designation: {s}"
             ))),
             Self::Naif(i) => Err(Error::ValueError(format!(
-                "Cannot pack a NAIF ID as a designation: {}",
-                i
+                "Cannot pack a NAIF ID as a designation: {i}"
             ))),
             Self::ObservatoryCode(s) => {
                 if s.len() != 3 {
                     return Err(Error::ValueError(format!(
-                        "MPC Earth Station Designation must be 3 characters: {}",
-                        s
+                        "MPC Earth Station Designation must be 3 characters: {s}",
                     )));
                 }
-                Ok(format!("{:0>3}", s))
+                Ok(format!("{s:0>3}"))
             }
             Self::Perm(num) => {
                 if *num < 620_000 {
@@ -393,25 +390,23 @@ impl Desig {
                     Ok(format!("~{:0>4}", &num_to_mpc_hex(num - 620_000)))
                 }
             }
-            Self::CometPerm(orbit_type, id, _) => Ok(format!("{:0>4}{}", id, orbit_type)),
+            Self::CometPerm(orbit_type, id, _) => Ok(format!("{id:0>4}{orbit_type}")),
             Self::PlanetSat(planet_id, sat_num) => match planet_id {
-                399 => Ok(format!("E{:0>3}S", sat_num)),
-                499 => Ok(format!("M{:0>3}S", sat_num)),
-                599 => Ok(format!("J{:0>3}S", sat_num)),
-                699 => Ok(format!("S{:0>3}S", sat_num)),
-                799 => Ok(format!("U{:0>3}S", sat_num)),
-                899 => Ok(format!("N{:0>3}S", sat_num)),
+                399 => Ok(format!("E{sat_num:0>3}S")),
+                499 => Ok(format!("M{sat_num:0>3}S")),
+                599 => Ok(format!("J{sat_num:0>3}S")),
+                699 => Ok(format!("S{sat_num:0>3}S")),
+                799 => Ok(format!("U{sat_num:0>3}S")),
+                899 => Ok(format!("N{sat_num:0>3}S")),
                 _ => Err(Error::ValueError(format!(
-                    "Invalid planetary satellite center NAIF ID: {}",
-                    planet_id
+                    "Invalid planetary satellite center NAIF ID: {planet_id}"
                 ))),
             },
 
             Self::Prov(des) => {
                 if des.len() <= 6 {
                     return Err(Error::ValueError(format!(
-                        "MPC Provisional Designation too short: {}",
-                        des
+                        "MPC Provisional Designation too short: {des}",
                     )));
                 }
                 let (year, des) = des
@@ -440,17 +435,13 @@ impl Desig {
                     ];
                     let century = YEAR_LOOKUP.iter().find(|&&x| x.0 == &year[0..2]).map_or(
                         Err(Error::ValueError(format!(
-                            "Invalid year in MPC Provisional Designation: {}",
-                            year
+                            "Invalid year in MPC Provisional Designation: {year}",
                         ))),
                         |&(_, c)| Ok(c),
                     )?;
                     let decade = &year[2..4];
                     let half_month = &des[..1];
-                    Ok(format!(
-                        "{}{}{}{}{}{}",
-                        century, decade, half_month, idx, idy, order
-                    ))
+                    Ok(format!("{century}{decade}{half_month}{idx}{idy}{order}"))
                 }
             }
             Self::CometProv(orbit_type, unpacked, fragment) => {
@@ -460,8 +451,7 @@ impl Desig {
                     .collect_tuple()
                     .ok_or_else(|| {
                         Error::ValueError(format!(
-                            "Invalid MPC Comet Provisional Designation: {}",
-                            unpacked
+                            "Invalid MPC Comet Provisional Designation: {unpacked}"
                         ))
                     })?;
 
@@ -470,8 +460,7 @@ impl Desig {
                     // 2033 L89-C
                     let num = des[1..].parse::<u32>().map_err(|_| {
                         Error::ValueError(format!(
-                            "Invalid MPC Comet Provisional Designation: {} {}",
-                            des, unpacked
+                            "Invalid MPC Comet Provisional Designation: {des} {unpacked}",
                         ))
                     })?;
                     let outnum = if num > 99 {
@@ -481,7 +470,7 @@ impl Desig {
                             num % 10
                         )
                     } else {
-                        format!("{:>02}", num)
+                        format!("{num:>02}")
                     };
 
                     Ok(format!(

--- a/src/kete_core/src/elements.rs
+++ b/src/kete_core/src/elements.rs
@@ -431,13 +431,7 @@ mod tests {
                                     for idx in 0..3 {
                                         assert!(
                                             (new_pos[idx] - pos[idx]).abs() < 1e-7,
-                                            "\n{:?}\n{:?}\n {:?}\n {:?}\n {:?}\n {:?}",
-                                            elem,
-                                            new_elem,
-                                            pos,
-                                            new_pos,
-                                            vel,
-                                            new_vel
+                                            "\n{elem:?}\n{new_elem:?}\n {pos:?}\n {new_pos:?}\n {vel:?}\n {new_vel:?}",
                                         );
                                         assert!((new_vel[idx] - vel[idx]).abs() < 1e-7);
                                     }
@@ -496,23 +490,11 @@ mod tests {
                                 for idx in 0..3 {
                                     assert!(
                                         (new_pos[idx] - pos[idx]).abs() < 1e-7,
-                                        "\n{:?}\n{:?}\n{:?}\n {:?}\n {:?}\n {:?}\n",
-                                        elem,
-                                        new_elem,
-                                        pos,
-                                        new_pos,
-                                        vel,
-                                        new_vel,
+                                        "\n{elem:?}\n{new_elem:?}\n{pos:?}\n {new_pos:?}\n {vel:?}\n {new_vel:?}",
                                     );
                                     assert!(
                                         (new_vel[idx] - vel[idx]).abs() < 1e-7,
-                                        "\n{:?}\n{:?}\n{:?}\n {:?}\n {:?}\n {:?}",
-                                        elem,
-                                        new_elem,
-                                        pos,
-                                        new_pos,
-                                        vel,
-                                        new_vel,
+                                        "\n{elem:?}\n{new_elem:?}\n{pos:?}\n {new_pos:?}\n {vel:?}\n {new_vel:?}",
                                     );
                                     assert!(
                                         (elem.true_anomaly().unwrap() - elem.mean_anomaly()).abs()

--- a/src/kete_core/src/io/serde_const_arr.rs
+++ b/src/kete_core/src/io/serde_const_arr.rs
@@ -28,7 +28,7 @@ where
     type Value = [T; N];
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&format!("an array of length {}", N))
+        formatter.write_str(&format!("an array of length {N}"))
     }
 
     #[inline]

--- a/src/kete_core/src/spice/pck.rs
+++ b/src/kete_core/src/spice/pck.rs
@@ -30,8 +30,7 @@ impl PckCollection {
         let file = DafFile::from_file(filename)?;
         if !matches!(file.daf_type, DAFType::Pck) {
             return Err(Error::IOError(format!(
-                "File {:?} is not a PCK formatted file.",
-                filename
+                "File {filename:?} is not a PCK formatted file."
             )))?;
         }
 
@@ -54,8 +53,7 @@ impl PckCollection {
         }
 
         Err(Error::DAFLimits(format!(
-            "Object ({}) does not have an PCK record for the target JD.",
-            id
+            "Object ({id}) does not have an PCK record for the target JD."
         )))?
     }
 
@@ -98,7 +96,7 @@ impl PckCollection {
                 let filename = path.to_str().unwrap();
                 if filename.to_lowercase().ends_with(".bpc") {
                     if let Err(err) = self.load_file(filename) {
-                        eprintln!("Failed to load PCK file {}: {}", filename, err);
+                        eprintln!("Failed to load PCK file {filename}: {err}");
                     }
                 }
             }

--- a/src/kete_core/src/spice/pck_segments.rs
+++ b/src/kete_core/src/spice/pck_segments.rs
@@ -40,8 +40,7 @@ impl TryFrom<PckArray> for PckSegment {
         match array.segment_type {
             2 => Ok(Self::Type2(array.try_into()?)),
             v => Err(Error::IOError(format!(
-                "PCK Segment type {:?} not supported.",
-                v
+                "PCK Segment type {v:?} not supported."
             ))),
         }
     }

--- a/src/kete_core/src/spice/sclk.rs
+++ b/src/kete_core/src/spice/sclk.rs
@@ -325,8 +325,7 @@ impl Sclk {
 
         if idx == 0 || idx > self.partition_start.len() {
             return Err(Error::ValueError(format!(
-                "Time {} is outside of the partition range.",
-                tick
+                "Time {tick} is outside of the partition range.",
             )));
         }
         let mut count = 0.0;
@@ -395,8 +394,7 @@ impl TryFrom<Vec<SclkToken>> for Sclk {
                     naif_id = Some(id);
                     if dtype != 1 {
                         return Err(Error::ValueError(format!(
-                            "SCLK clock type must be 1, found {}.",
-                            dtype
+                            "SCLK clock type must be 1, found {dtype}.",
                         )));
                     }
                 } // Data type is always 1
@@ -410,8 +408,7 @@ impl TryFrom<Vec<SclkToken>> for Sclk {
                     }
                     if n < 1 {
                         return Err(Error::ValueError(format!(
-                            "SCLK N_FIELDS must be at least 1, found {}.",
-                            n
+                            "SCLK N_FIELDS must be at least 1, found {n}.",
                         )));
                     }
                     naif_id = Some(id);
@@ -513,14 +510,13 @@ impl TryFrom<Vec<SclkToken>> for Sclk {
                     // require that val be either 1 or 2
                     if val != 1 && val != 2 {
                         return Err(Error::ValueError(format!(
-                            "SCLK Time System must be 1 (TDB) or 2 (TT), found {}.",
-                            val
+                            "SCLK Time System must be 1 (TDB) or 2 (TT), found {val}.",
                         )));
                     }
                     tdb = Some(val == 1);
                 }
                 SclkToken::Unknown(s) => {
-                    return Err(Error::ValueError(format!("Unknown SCLK line: {}", s)));
+                    return Err(Error::ValueError(format!("Unknown SCLK line: {s}")));
                 }
             }
         }

--- a/src/kete_core/src/spice/spk_segments.rs
+++ b/src/kete_core/src/spice/spk_segments.rs
@@ -476,7 +476,14 @@ pub(in crate::spice) struct SpkSegmentType9 {
 impl From<SpkArray> for SpkSegmentType9 {
     fn from(array: SpkArray) -> Self {
         let n_records = array.daf[array.daf.len() - 1] as usize;
-        let poly_degree = array.daf[array.daf.len() - 2] as usize;
+        let mut poly_degree = array.daf[array.daf.len() - 2] as usize;
+
+        if poly_degree + 1 > n_records {
+            eprintln!(
+                "Spk Segment Type 9 must have at least as many records as the polynomial degree, n_records={n_records}, poly_degree={poly_degree}",
+            );
+            poly_degree = n_records - 1;
+        }
 
         Self {
             array,
@@ -707,7 +714,14 @@ pub(in crate::spice) struct SpkSegmentType13 {
 impl From<SpkArray> for SpkSegmentType13 {
     fn from(array: SpkArray) -> Self {
         let n_records = array.daf[array.daf.len() - 1] as usize;
-        let window_size = array.daf[array.daf.len() - 2] as usize;
+        let mut window_size = array.daf[array.daf.len() - 2] as usize;
+
+        if window_size > n_records {
+            eprintln!(
+                "Spk Segment Type 13 must have at least as many records as the window size, n_records={n_records}, window_size={window_size}",
+            );
+            window_size = n_records;
+        }
 
         Self {
             array,
@@ -812,7 +826,7 @@ impl TryFrom<SpkArray> for SpkSegmentType18 {
     type Error = Error;
     fn try_from(array: SpkArray) -> KeteResult<Self> {
         let n_records = array.daf[array.daf.len() - 1] as usize;
-        let window_size = array.daf[array.daf.len() - 2] as usize;
+        let mut window_size = array.daf[array.daf.len() - 2] as usize;
         let subtype = array.daf[array.daf.len() - 3] as usize;
         let record_size = {
             if subtype == 0 {
@@ -825,6 +839,12 @@ impl TryFrom<SpkArray> for SpkSegmentType18 {
                 ));
             }
         };
+        if window_size > n_records {
+            eprintln!(
+                "Spk Segment Type 18 must have at least as many records as the window size, n_records={n_records}, window_size={window_size}",
+            );
+            window_size = n_records;
+        }
 
         Ok(Self {
             array,

--- a/src/kete_core/src/util.rs
+++ b/src/kete_core/src/util.rs
@@ -236,12 +236,11 @@ fn parse_str_to_floats(text: &str) -> KeteResult<(f64, f64, f64)> {
         space0,
     )
     .parse(text)
-    .map_err(|_| Error::ValueError(format!("Failed to parse string: {}", text)))?;
+    .map_err(|_| Error::ValueError(format!("Failed to parse string: {text}")))?;
 
     if !rem.trim().is_empty() {
         return Err(Error::ValueError(format!(
-            "Failed to parse: {} parsing failed at {}",
-            text, rem
+            "Failed to parse: {text} parsing failed at {rem}",
         )));
     }
 
@@ -251,16 +250,14 @@ fn parse_str_to_floats(text: &str) -> KeteResult<(f64, f64, f64)> {
         3 => (hms[0], hms[1], hms[2]),
         _ => {
             return Err(Error::ValueError(format!(
-                "String has too many numbers: {}",
-                text
+                "String has too many numbers: {text}",
             )));
         }
     };
 
     if m.is_sign_negative() || s.is_sign_negative() {
         return Err(Error::ValueError(format!(
-            "String has negative values in the second or third terms: {}",
-            text
+            "String has negative values in the second or third terms: {text}"
         )));
     }
     Ok((h, m, s))
@@ -294,10 +291,7 @@ mod tests {
             let converted_deg = hms.to_degrees();
             assert!(
                 (converted_deg - deg).abs() < 1e-10,
-                "Failed for deg: {} != {}  {:?}",
-                deg,
-                converted_deg,
-                hms,
+                "Failed for deg: {deg} != {converted_deg}  {hms:?}",
             );
         }
     }
@@ -310,9 +304,7 @@ mod tests {
             let converted_deg = hms.to_degrees();
             assert!(
                 (converted_deg - deg).abs() < 1e-10,
-                "Failed for deg: {} != {}",
-                deg,
-                converted_deg
+                "Failed for deg: {deg} != {converted_deg}",
             );
         }
     }
@@ -433,16 +425,13 @@ mod tests {
                     let second = second as f64 + 0.123;
                     let hms = Degrees::try_from_hours_minutes_seconds(hour as f64, minute, second)
                         .unwrap();
-                    let hms_str = format!("{:02} {:02} {:06.3}", hour, minute, second);
+                    let hms_str = format!("{hour:02} {minute:02} {second:06.3}");
                     assert!(
                         (hms.to_degrees()
                             - Degrees::try_from_hms_str(&hms_str).unwrap().to_degrees())
                         .abs()
                             < 1e-8,
-                        "Failed for {}:{}:{}",
-                        hour,
-                        minute,
-                        second
+                        "Failed for {hour}:{minute}:{second}",
                     );
                 }
             }
@@ -459,16 +448,13 @@ mod tests {
                     let dms: Degrees =
                         Degrees::try_from_degrees_minutes_seconds(degree as f64, minute, second)
                             .unwrap();
-                    let dms_str = format!("{:02} {:02} {:06.3}", degree, minute, second);
+                    let dms_str = format!("{degree:02} {minute:02} {second:06.3}");
                     assert!(
                         (dms.to_degrees()
                             - Degrees::try_from_dms_str(&dms_str).unwrap().to_degrees())
                         .abs()
                             < 1e-8,
-                        "Failed for {}:{}:{}",
-                        degree,
-                        minute,
-                        second,
+                        "Failed for {degree}:{minute}:{second}",
                     );
                 }
             }


### PR DESCRIPTION
Some SPK files in the wild have poorly formatted contents, not naming names. These are interpolating a 12th order model with as low as 4 data points. This change in the code will automatically reduce the order of the polynomial fit if not enough data is available. When this happens, a warning is emitted to stderr. Not the prettiest, but verbose enough that people should know the file is badly made.