### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v2.1.0]
 
 ### Added
 
@@ -510,7 +510,8 @@ Initial Release
 
 
 [Unreleased]: https://github.com/dahlend/kete/tree/main
-[2.0.0]: https://github.com/dahlend/kete/releases/tag/v1.1.0
+[2.1.0]: https://github.com/dahlend/kete/releases/tag/v2.1.0
+[2.0.0]: https://github.com/dahlend/kete/releases/tag/v2.0.0
 [1.1.0]: https://github.com/dahlend/kete/releases/tag/v1.1.0
 [1.0.8]: https://github.com/dahlend/kete/releases/tag/v1.0.8
 [1.0.7]: https://github.com/dahlend/kete/releases/tag/v1.0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["src/kete_core"]
 default-members = ["src/kete_core"]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "2.0.0"
+version = "2.1.0"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "dardahlen@gmail.com"},

--- a/src/kete/spice.py
+++ b/src/kete/spice.py
@@ -306,3 +306,7 @@ def moon_illumination_frac(jd: float | Time, observer: str = "399"):
     moon2earth = -get_state("moon", jd, center=observer).pos
     perc = 1.0 - moon2sun.angle_between(moon2earth) / 180
     return 0.5 - np.cos(np.pi * perc) / 2
+
+
+# Download missing files on import
+_download_core_files()


### PR DESCRIPTION
### Added

- Added support for SPHEREx public data, this includes a custom constructed SPICE
  kernel.
- Added support for computing sunrise and sunset times at any location on Earth.
- Added support for approximate earth location computation, to enable precovery work
  on frames from before 1972.

### Changed

- Moved name lookups for SPICE and Observatory codes to the rust backend. This speeds
  up lookup of states in python by about a factor of 2.
- Renamed `wgs_84.rs` to `earth.rs` and moved Earth related computations into it.

### Fixed

- `HorizonsProperties` sampling and queries to horizons is more robust to unexpected
  responses from the Horizons service.
