### PR TITLE
Removed excessive angle conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the angle calculations of orbital elements in `State` objects where they were
   being converted to degrees twice, causing them to be multiplied by 360/2pi.
-- Fixed a sign error in the phase correction curve for V mag estimations.
 
 ## [v2.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v2.1.1]
+
+### Fixed
+
+- Fixed the angle calculations of orbital elements in `State` objects where they were
+  being converted to degrees twice, causing them to be multiplied by 360/2pi.
+- Fixed a sign error in the phase correction curve for V mag estimations.
+
 ## [v2.1.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ build-backend = "maturin"
 python-source = "src"
 module-name = "kete._core"
 manifest-path = "Cargo.toml"
+sdist-include = ["LICENSE", "Readme.md"]
 
 [project.optional-dependencies]
 dev = ["ruff",

--- a/src/kete/rust/state.rs
+++ b/src/kete/rust/state.rs
@@ -198,13 +198,13 @@ impl PyState {
     /// Inclination of the orbit in degrees.
     #[getter]
     pub fn inclination(&mut self) -> f64 {
-        self.elements().inclination().to_degrees()
+        self.elements().inclination()
     }
 
     /// Longitude of the ascending node of the orbit in degrees.
     #[getter]
     pub fn lon_of_ascending(&mut self) -> f64 {
-        self.elements().lon_of_ascending().to_degrees()
+        self.elements().lon_of_ascending()
     }
 
     /// Perihelion time of the orbit in JD.
@@ -216,7 +216,7 @@ impl PyState {
     /// Argument of Perihelion of the orbit in degrees.
     #[getter]
     pub fn peri_arg(&mut self) -> f64 {
-        self.elements().peri_arg().to_degrees()
+        self.elements().peri_arg()
     }
 
     /// Distance of Perihelion of the orbit in au.
@@ -234,7 +234,7 @@ impl PyState {
     /// Mean Motion of the orbit in degrees.
     #[getter]
     pub fn mean_motion(&mut self) -> f64 {
-        self.elements().mean_motion().to_degrees()
+        self.elements().mean_motion()
     }
 
     /// Orbital Period in days, nan if non-elliptical.
@@ -246,19 +246,19 @@ impl PyState {
     /// Eccentric Anomaly in degrees.
     #[getter]
     pub fn eccentric_anomaly(&mut self) -> PyResult<f64> {
-        self.elements().eccentric_anomaly().map(|x| x.to_degrees())
+        self.elements().eccentric_anomaly()
     }
 
     /// Mean Anomaly in degrees.
     #[getter]
     pub fn mean_anomaly(&mut self) -> f64 {
-        self.elements().mean_anomaly().to_degrees()
+        self.elements().mean_anomaly()
     }
 
     /// True Anomaly in degrees.
     #[getter]
     pub fn true_anomaly(&mut self) -> PyResult<f64> {
-        self.elements().true_anomaly().map(|x| x.to_degrees())
+        self.elements().true_anomaly()
     }
 
     /// Designation of the object if defined.

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -264,7 +264,7 @@ impl HGParams {
         }
 
         let correction = hg_phase_curve_correction(self.g_param, phase).log10();
-        self.h_mag + 5.0 * (obj_r * obj2obs_r).log10() + 2.5 * correction
+        self.h_mag + 5.0 * (obj_r * obj2obs_r).log10() - 2.5 * correction
     }
 
     /// Calculate the reflected light flux from an object using the IAU phase correction curve.

--- a/src/kete_core/src/flux/reflected.rs
+++ b/src/kete_core/src/flux/reflected.rs
@@ -264,7 +264,7 @@ impl HGParams {
         }
 
         let correction = hg_phase_curve_correction(self.g_param, phase).log10();
-        self.h_mag + 5.0 * (obj_r * obj2obs_r).log10() - 2.5 * correction
+        self.h_mag + 5.0 * (obj_r * obj2obs_r).log10() + 2.5 * correction
     }
 
     /// Calculate the reflected light flux from an object using the IAU phase correction curve.

--- a/src/tests/test_state.py
+++ b/src/tests/test_state.py
@@ -18,21 +18,29 @@ class TestlState:
             epoch=123456,
             desig="test",
             eccentricity=0.1,
-            inclination=0,
+            inclination=10,
             peri_dist=0.45,
-            peri_arg=0,
-            lon_of_ascending=0,
+            peri_arg=30,
+            lon_of_ascending=45,
             peri_time=123456,
         ).state
         assert vs.jd == 123456
         elem = vs.elements
         assert np.isclose(elem.eccentricity, 0.1)
-        assert np.isclose(elem.inclination, 0)
-        assert np.isclose(elem.peri_arg, 0)
-        assert np.isclose(elem.lon_of_ascending, 0)
+        assert np.isclose(elem.inclination, 10)
+        assert np.isclose(elem.peri_arg, 30)
+        assert np.isclose(elem.lon_of_ascending, 45)
         assert np.isclose(elem.peri_time, 123456)
         assert np.isclose(elem.peri_dist, 0.45)
         assert np.isclose(elem.semi_major, 0.5)
+
+        assert np.isclose(vs.eccentricity, 0.1)
+        assert np.isclose(vs.inclination, 10)
+        assert np.isclose(vs.peri_arg, 30)
+        assert np.isclose(vs.lon_of_ascending, 45)
+        assert np.isclose(vs.peri_time, 123456)
+        assert np.isclose(vs.peri_dist, 0.45)
+        assert np.isclose(vs.semi_major, 0.5)
 
     @pytest.mark.parametrize("ecc", [0.1, 0.5, 1.0, 1.3])
     @pytest.mark.parametrize("inc", [0.1, 2])


### PR DESCRIPTION
When the convenience orbital element conversion aliases were added to states, an excessive degree conversion was added by accident.

This PR removes that excessive calculation.