### PR TITLE
Update SPHEREx docs

### DIFF
--- a/docs/tutorials/spherex.rst
+++ b/docs/tutorials/spherex.rst
@@ -28,9 +28,10 @@ for SPHEREx.
     # Download all of the fields of view from IRSA.
     # This does not download the images! This only downloads the metadata
     # which describes the position on sky of every frame.
-    # Currently this is an approximation, as the SPICE kernel for SPHEREx
-    # is not public, so these FOVs use the Earth center as a stand-in for
-    # the position of the telescope.
+    # The SPICE kernel for SPHEREx is not publicly available, as a result of this
+    # This uses a custom SPICE kernel, built from publicly available data.
+    # THIS IS NOT AN OFFICIAL KERNEL! However it matches the positions available
+    # on JPL Horizons to within about 30km.
     fovs = kete.spherex.fetch_fovs()
 
     # Load the list of all known objects from the MPC.

--- a/src/kete/spherex.py
+++ b/src/kete/spherex.py
@@ -74,8 +74,9 @@ def fetch_fovs(update_cache=False):
     Download every public Spherex Field of View from IRSA.
 
     Currently the position of Spherex is not publicly available, so
-    the fields of view are constructed with the observer position being at the
-    center of the Earth.
+    kete uses a custom SPICE kernel which has been reconstructed from publicly
+    available data. This SPICE kernel is NOT official, and matches JPL Horizons
+    values to within about 30km.
     """
     table = fetch_observation_table(update_cache=update_cache)
     table = table[[s is not None for s in table["s_region"]]]

--- a/src/kete_core/src/spice/spk_segments.rs
+++ b/src/kete_core/src/spice/spk_segments.rs
@@ -148,6 +148,9 @@ impl SpkSegment {
 ///
 /// <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/spk.html#Type%201:%20Modified%20Difference%20Arrays>
 ///
+// This format might be derived from works related to this paper:
+// Recurrence Relations for Computing With Modified Divided Differences*
+// Fred Krogh 1979
 #[derive(Debug)]
 pub(in crate::spice) struct SpkSegmentType1 {
     array: SpkArray,


### PR DESCRIPTION
SPHEREx documentation was not up to date. The FoV positions are being computed from the custom SPICE kernel, the docs have been updated to match this.