### PR TITLE
Move WISE SPICE kernel download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `kete.spice.get_state` now accepts MPC Observatory codes as well.
+- WISE SPICE kernel download location moved.
 
 ### Fixed
 

--- a/src/kete/horizons.py
+++ b/src/kete/horizons.py
@@ -475,8 +475,8 @@ def fetch_spice_kernel(
     if not os.path.isdir(dir_path):
         os.makedirs(dir_path)
 
-    jd_s_str = jd_start.to_datetime().strftime("%Y-%m-%d")
-    jd_e_str = jd_end.to_datetime().strftime("%Y-%m-%d")
+    jd_s_str = "{:d}-{:02d}-{:0.0f}".format(*jd_start.ymd)
+    jd_e_str = "{:d}-{:02d}-{:0.0f}".format(*jd_end.ymd)
     cap = f"CAP<{apparition_year}%3B" if comet else ""
     response = requests.get(
         f"https://ssd.jpl.nasa.gov/api/horizons.api?COMMAND='DES={spk_id}%3B{cap}'"

--- a/src/kete/mpc.py
+++ b/src/kete/mpc.py
@@ -188,7 +188,7 @@ def fetch_known_comet_orbit_data(force_download=False):
     objs = download_json(url, force_download)
     objects = []
     for comet in objs:
-        name = pack_designation(comet.get("Designation_and_name").split("(")[0])
+        name = comet.get("Designation_and_name").split("(")[0]
         peri_time = (
             comet["Year_of_perihelion"],
             comet["Month_of_perihelion"],

--- a/src/kete/rust/fovs/checks.rs
+++ b/src/kete/rust/fovs/checks.rs
@@ -20,7 +20,7 @@ use crate::{simult_states::PySimultaneousStates, vector::VectorLike};
 /// dt: float
 ///     Length of time in days where 2-body mechanics is a good approximation.
 /// include_asteroids: bool
-///     Include the 5 largest asteroids during the computation.
+///     Include the additional registered gravitational masses during the computation.
 #[pyfunction]
 #[pyo3(name = "fov_state_check", signature = (obj_state, fovs, dt_limit=3.0, include_asteroids=false))]
 pub fn fov_checks_py(

--- a/src/kete/spice.py
+++ b/src/kete/spice.py
@@ -127,7 +127,7 @@ def _download_core_files():
 
     # required files:
     de440 = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/de440s.bsp"
-    wise = "https://github.com/Caltech-IPAC/kete/raw/refs/heads/main/src/kete_core/data/wise.bsp"
+    wise = "https://github.com/dahlend/kete/blob/main/docs/data/wise.bsp"
     spherex = (
         "https://github.com/dahlend/kete/raw/refs/heads/main/docs/data/spherex.bsp"
     )


### PR DESCRIPTION
Move a copy of the WISE SPICE Kernel into kete, as the previous download location appears to be going away.

Fixes #58 