### PR TITLE
Add support for MAST TAP queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Added
+
+- Added support for STScI MAST Tap queries.
+
 ### Changed
 
 - Updated observability example (simpler and faster).

--- a/src/kete/tap.py
+++ b/src/kete/tap.py
@@ -25,11 +25,14 @@ IRSA_URL = "https://irsa.ipac.caltech.edu"
 IRSA_TAP_URL = "https://irsa.ipac.caltech.edu/TAP/async"
 CADC_TAP_URL = "https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/argus/async"
 GAIA_TAP_URL = "https://gaia.aip.de/tap/async"
+MAST_TAP_URL = "https://mast.stsci.edu/vo-tap/api/v0.1/caom/async"
+
 
 TAP_SERVERS = {
     "IRSA": IRSA_TAP_URL,
     "CADC": CADC_TAP_URL,
     "GAIA": GAIA_TAP_URL,
+    "MAST": MAST_TAP_URL,
 }
 """
 Defined TAP servers for easy lookup.
@@ -217,7 +220,7 @@ class AsyncTapQuery:
         self.update_cache = update_cache
         self.cache = cache
 
-        self.data = dict(FORMAT="CSV", QUERY=query, LANG="ADQL", REQUEST="doQuery")
+        self.data = dict(FORMAT="csv", QUERY=query, LANG="ADQL", REQUEST="doQuery")
         files = None
         if upload_table is not None:
             self.data["UPLOAD"] = "my_table,param:table.tbl"


### PR DESCRIPTION
This adds support for queries to the STScI MAST TAP service. Basically this just added a URL and changed one value to lowercase. (everyone else besides MAST can handle "CSV" or "csv", but MAST is picky and *demands* lowercase "csv")