### PR TITLE
Release v2.1.5

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [313]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-13]
         include:
           # Window 64 bit
           - os: windows-latest
@@ -40,6 +40,11 @@ jobs:
           # MacOS - latest is now arm64, no longer x86_64
           - os: macos-latest
             platform_id: macosx_arm64
+            sdist: 
+
+          # MacOS - last remaining intel mac
+          - os: macos-13
+            platform_id: macosx_x86_64
             sdist: 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.1.5]
+
+### Added
+
+- Due to popular request, build kete for Intel macs.
+
 
 ## [v2.1.4]
 
@@ -568,6 +574,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/dahlend/kete/tree/main
+[2.1.5]: https://github.com/dahlend/kete/releases/tag/v2.1.5
 [2.1.4]: https://github.com/dahlend/kete/releases/tag/v2.1.4
 [2.1.3]: https://github.com/dahlend/kete/releases/tag/v2.1.3
 [2.1.2]: https://github.com/dahlend/kete/releases/tag/v2.1.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["src/kete_core"]
 default-members = ["src/kete_core"]
 
 [workspace.package]
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "2.1.4"
+version = "2.1.5"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "dardahlen@gmail.com"},

--- a/src/kete_core/src/constants/gravity.rs
+++ b/src/kete_core/src/constants/gravity.rs
@@ -102,7 +102,8 @@ impl FromStr for GravParams {
         let mut iter = row.split_whitespace();
         let naif_id = iter.next();
         let mass = iter.next();
-        let radius = iter.next().unwrap_or("0.0");
+        // default to 100m if not present
+        let radius = iter.next().unwrap_or("6.684587122268446e-10");
         if naif_id.is_none() || mass.is_none() {
             return Err(Error::IOError(format!(
                 "GravParams row incorrectly formatted. {row}",
@@ -333,7 +334,7 @@ fn j2_correction(rel_pos: &Vector3<f64>, radius: f32, j2: &f64, mass: &f64) -> V
     let z_squared = 5.0 * (rel_pos.z / r).powi(2);
 
     // this is formatted a little funny in an attempt to reduce numerical noise
-    // 3/2 * j2 * mass * earth_r^2 / distance^5
+    // 3/2 * j2 * mass * radius^2 / distance^5
     let coef = 1.5 * j2 * mass * (radius as f64 / r).powi(2) * r.powi(-3);
     Vector3::<f64>::new(
         rel_pos.x * coef * (z_squared - 1.0),


### PR DESCRIPTION
Build release wheels for Intel Macs.

This release is only to trigger building release wheels for intel macs.