### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.0]
 
 ## Added
 
@@ -16,15 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   greatly reduce their size. This was done with the ~600MB Spitzer kernel and it was
   reduced to less than 1MB and is included with Kete, less than 1km max difference
   across the entire file.
+- Added support for downloading JPL Horizons Radar observations.
 
 ### Changed
 
 - HorizonsProperties now has its query and caching done in rust. Python api unchanged.
+- MPC Observations are now cached.
 
 ### Fixed
 - SPK lookups were failing to resolve in some cases when the planets were unloaded and
   reloaded.
-- Improved Initial Orbit Determination and convergence of orbit fitting.
+- Improved Initial Orbit Determination significantly.
+- Improved convergence and outlier rejection in orbit fitting.
 
 
 ## [3.0.1]
@@ -683,6 +686,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/dahlend/kete/tree/main
+[3.1.0]: https://github.com/dahlend/kete/releases/tag/v3.1.0
 [3.0.1]: https://github.com/dahlend/kete/releases/tag/v3.0.1
 [3.0.0]: https://github.com/dahlend/kete/releases/tag/v3.0.0
 [2.1.5]: https://github.com/dahlend/kete/releases/tag/v2.1.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["src/kete_core", "src/kete_stats", "src/kete_fitting", "src/kete_flux
 default-members = ["src/kete_core", "src/kete_stats", "src/kete_fitting", "src/kete_flux", "src/kete_spice"]
 
 [workspace.package]
-version = "3.0.1"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.95"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "3.0.1"
+version = "3.1.0"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "dardahlen@gmail.com"},


### PR DESCRIPTION
This release is about 2 things:
- Improving orbit fitting to make it more stable/reliable.
- Adding Spitzer query tools.


## [3.1.0]

## Added

- Non-Gravitational orbit fitting now accepts `NaN` to indicate to not fit a parameter.
- Support for Spitzer, including fetching FoVs and frames.
- Initial support for writing some SPICE files.
- SPK Repacking, where SPICE kernels are repacked into different SPICE formats which can
  greatly reduce their size. This was done with the ~600MB Spitzer kernel and it was
  reduced to less than 1MB and is included with Kete, less than 1km max difference
  across the entire file.
- Added support for downloading JPL Horizons Radar observations.

### Changed

- HorizonsProperties now has its query and caching done in rust. Python api unchanged.
- MPC Observations are now cached.

### Fixed
- SPK lookups were failing to resolve in some cases when the planets were unloaded and
  reloaded.
- Improved Initial Orbit Determination significantly.
- Improved convergence and outlier rejection in orbit fitting.