### PR TITLE
Release v3.2.1 - Minor bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1]
+
+### Fixed
+
+- Minor bug in orbit fitting, non-gravitational force fits were being dropped if the
+  fit was worse than without non-gravs. This behavior is unexpected for users so was
+  reverted.
+
+### Added
+
+- Added the algorithm used by JPL Scout as `kete.orbit_fitting.fit_orbit_ranging`.
+
+
 ## [3.2.0]
 
 ### Added
@@ -721,6 +734,7 @@ Initial Release
 
 
 [Unreleased]: https://github.com/dahlend/kete/tree/main
+[3.2.1]: https://github.com/dahlend/kete/releases/tag/v3.2.1
 [3.2.0]: https://github.com/dahlend/kete/releases/tag/v3.2.0
 [3.1.0]: https://github.com/dahlend/kete/releases/tag/v3.1.0
 [3.0.1]: https://github.com/dahlend/kete/releases/tag/v3.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = ["src/kete_core", "src/kete_stats", "src/kete_fitting", "src/kete_flux
 default-members = ["src/kete_core", "src/kete_stats", "src/kete_fitting", "src/kete_flux", "src/kete_spice"]
 
 [workspace.package]
-version = "3.2.0"
+version = "3.2.1"
 edition = "2024"
 rust-version = "1.95"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kete"
-version = "3.2.0"
+version = "3.2.1"
 description = "Kete Asteroid Survey Tools"
 readme = "README.md"
 authors = [{name = "Dar Dahlen", email = "dardahlen@gmail.com"},


### PR DESCRIPTION
This is a minor version release to fix an orbit fitting bug.

## [3.2.1]

### Fixed

- Minor bug in orbit fitting, non-gravitational force fits were being dropped if the
  fit was worse than without non-gravs. This behavior is unexpected for users so was
  reverted.

### Added

- Added the algorithm used by JPL Scout as `kete.orbit_fitting.fit_orbit_ranging`.