### PR TITLE
Generalize rust state constructor

### DIFF
--- a/src/kete/rust/fitting.rs
+++ b/src/kete/rust/fitting.rs
@@ -881,8 +881,7 @@ impl PyOrbitSamples {
                 // VectorLike::Arr would incorrectly interpret them as
                 // Ecliptic and apply an unwanted rotation.
                 let desig_val = Desig::Name(desig.clone());
-                let st: State<Equatorial> =
-                    State::new(desig_val, Time::new(epoch_jd), pos.into(), vel.into(), 10);
+                let st: State<Equatorial> = State::new(desig_val, epoch_jd, pos, vel, 10);
                 // From<State<Equatorial>> sets Ecliptic display.
                 Ok(st.into())
             })
@@ -1101,13 +1100,7 @@ impl PyRangingSamples {
                     d[4] - sun_state.vel[1],
                     d[5] - sun_state.vel[2],
                 ];
-                let st: State<Equatorial> = State::new(
-                    Desig::Empty,
-                    Time::new(epoch_jd),
-                    pos.into(),
-                    vel.into(),
-                    10,
-                );
+                let st: State<Equatorial> = State::new(Desig::Empty, epoch_jd, pos, vel, 10);
                 Ok(st.into())
             })
             .collect()

--- a/src/kete/rust/spice/ck.rs
+++ b/src/kete/rust/spice/ck.rs
@@ -60,7 +60,7 @@ pub fn ck_sc_frame_to_equatorial(
     let cks = LOADED_CK.try_read().unwrap();
     let (time, frame) = cks.try_get_frame(time.jd, instrument_id)?;
 
-    let (pos, _) = frame.to_equatorial(vec.into(), [0.0; 3].into())?;
+    let (pos, _) = frame.to_equatorial(vec, [0.0; 3])?;
 
     let vec = PyVector::new(pos.into(), PyFrames::Equatorial);
 
@@ -84,7 +84,7 @@ pub fn ck_sc_equatorial_to_frame(
     let cks = LOADED_CK.try_read().unwrap();
     let (time, frame) = cks.try_get_frame(time.jd, instrument_id)?;
 
-    let (pos, _) = frame.from_equatorial(vec.into(), [0.0; 3].into())?;
+    let (pos, _) = frame.from_equatorial(vec, [0.0; 3])?;
 
     Ok((time.into(), pos.into()))
 }

--- a/src/kete/rust/spice/pck.rs
+++ b/src/kete/rust/spice/pck.rs
@@ -58,9 +58,9 @@ pub fn pck_earth_frame_py(
 
     let frame = pcks.try_get_orientation(3000, jd)?;
 
-    let (pos, vel) = frame.to_equatorial(pos.into(), [0.0, 0.0, 0.0].into())?;
+    let (pos, vel) = frame.to_equatorial(pos, [0.0, 0.0, 0.0])?;
 
-    let mut state: State<Equatorial> = State::new(desig, jd, pos.into(), vel.into(), 399);
+    let mut state: State<Equatorial> = State::new(desig, jd, pos, vel, 399);
 
     spks.try_change_center(&mut state, new_center)?;
 
@@ -92,7 +92,7 @@ pub fn pck_state_to_earth(state: PyState) -> PyResult<(f64, f64, f64)> {
         .raw;
     let frame = pcks.try_get_orientation(3000, state.epoch)?;
 
-    let (pos, _) = frame.from_equatorial(state.pos.into(), state.vel.into())?;
+    let (pos, _) = frame.from_equatorial(state.pos, state.vel)?;
     let [x, y, z] = pos.into();
     let (lat, lon, height) = ecef_to_geodetic_lat_lon(
         x * constants::AU_KM,

--- a/src/kete/rust/state.rs
+++ b/src/kete/rust/state.rs
@@ -86,7 +86,7 @@ impl PyState {
         let vel = vel.into_vector(frame);
 
         let center_id = center_id.unwrap_or(10);
-        let state = State::new(desig, jd.into(), pos, vel, center_id);
+        let state = State::new(desig, jd, pos, vel, center_id);
         Self {
             raw: state,
             frame,

--- a/src/kete_core/benches/propagation.rs
+++ b/src/kete_core/benches/propagation.rs
@@ -13,50 +13,42 @@ use pprof::criterion::{Output, PProfProfiler};
 static CIRCULAR: std::sync::LazyLock<State<Ecliptic, SunCenter>> = std::sync::LazyLock::new(|| {
     State::new(
         Desig::Name("Circular".into()),
-        2451545.0.into(),
-        [0.0, 1., 0.0].into(),
-        [-constants::GMS_SQRT, 0.0, 0.0].into(),
-        10,
+        2451545.0,
+        [0.0, 1., 0.0],
+        [-constants::GMS_SQRT, 0.0, 0.0],
+        SunCenter,
     )
-    .try_into()
-    .unwrap()
 });
 static ELLIPTICAL: std::sync::LazyLock<State<Ecliptic, SunCenter>> =
     std::sync::LazyLock::new(|| {
         State::new(
             Desig::Name("Elliptical".into()),
-            2451545.0.into(),
-            [0.0, 1.5, 0.0].into(),
-            [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            10,
+            2451545.0,
+            [0.0, 1.5, 0.0],
+            [-constants::GMS_SQRT, 0.0, 0.0],
+            SunCenter,
         )
-        .try_into()
-        .unwrap()
     });
 static PARABOLIC: std::sync::LazyLock<State<Ecliptic, SunCenter>> =
     std::sync::LazyLock::new(|| {
         State::new(
             Desig::Name("Parabolic".into()),
-            2451545.0.into(),
-            [0.0, 2., 0.0].into(),
-            [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            10,
+            2451545.0,
+            [0.0, 2., 0.0],
+            [-constants::GMS_SQRT, 0.0, 0.0],
+            SunCenter,
         )
-        .try_into()
-        .unwrap()
     });
 
 static HYPERBOLIC: std::sync::LazyLock<State<Ecliptic, SunCenter>> =
     std::sync::LazyLock::new(|| {
         State::new(
             Desig::Name("Hyperbolic".into()),
-            2451545.0.into(),
-            [0.0, 3., 0.0].into(),
-            [-constants::GMS_SQRT, 0.0, 0.0].into(),
-            10,
+            2451545.0,
+            [0.0, 3., 0.0],
+            [-constants::GMS_SQRT, 0.0, 0.0],
+            SunCenter,
         )
-        .try_into()
-        .unwrap()
     });
 
 fn prop_2_body_kepler(state: &State<Ecliptic, SunCenter>, dt: f64) {

--- a/src/kete_core/src/desigs.rs
+++ b/src/kete_core/src/desigs.rs
@@ -654,6 +654,21 @@ impl Desig {
     }
 }
 
+impl From<Option<i32>> for Desig {
+    fn from(value: Option<i32>) -> Self {
+        match value {
+            Some(id) => Self::Naif(id),
+            None => Self::Empty,
+        }
+    }
+}
+
+impl From<i32> for Desig {
+    fn from(value: i32) -> Self {
+        Self::Naif(value)
+    }
+}
+
 impl Display for Desig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&match self {

--- a/src/kete_core/src/elements.rs
+++ b/src/kete_core/src/elements.rs
@@ -33,7 +33,7 @@
 
 use crate::constants::GMS_SQRT;
 use crate::forces::GravParams;
-use crate::frames::{CenterBody, Ecliptic};
+use crate::frames::{CenterBody, DynCenter, Ecliptic};
 use crate::kepler::{PARABOLIC_ECC_LIMIT, compute_eccentric_anomaly, compute_true_anomaly};
 use crate::prelude::{Desig, KeteResult, State};
 use crate::time::{TDB, Time};
@@ -95,7 +95,10 @@ impl CometElements {
 
     /// Create cometary elements from a state.
     #[must_use]
-    pub fn from_state<C: CenterBody>(state: &State<Ecliptic, C>) -> Self {
+    pub fn from_state<C: CenterBody>(state: &State<Ecliptic, C>) -> Self
+    where
+        DynCenter: From<C>,
+    {
         let gm_sqrt = Self::gm_sqrt_for_center(state.center_id());
         Self::from_pos_vel(
             state.desig.clone(),
@@ -232,8 +235,8 @@ impl CometElements {
         Ok(State::new(
             self.desig.clone(),
             self.epoch,
-            pos.into(),
-            vel.into(),
+            pos,
+            vel,
             self.center_id,
         ))
     }

--- a/src/kete_core/src/frames/center.rs
+++ b/src/kete_core/src/frames/center.rs
@@ -12,7 +12,10 @@ use std::fmt::Debug;
 /// Trait for center-body types used in [`State`](crate::state::State).
 ///
 /// Implementors provide the NAIF id of the center body at runtime.
-pub trait CenterBody: Sized + Sync + Send + Clone + Copy + Debug + PartialEq {
+pub trait CenterBody: Sized + Sync + Send + Clone + Copy + Debug + PartialEq
+where
+    DynCenter: From<Self>,
+{
     /// NAIF id of the center body.
     fn center_id(&self) -> i32;
 }
@@ -52,6 +55,24 @@ impl CenterBody for DynCenter {
 impl From<i32> for DynCenter {
     fn from(id: i32) -> Self {
         Self(id)
+    }
+}
+
+impl From<SSB> for DynCenter {
+    fn from(_: SSB) -> Self {
+        Self(0)
+    }
+}
+
+impl From<SunCenter> for DynCenter {
+    fn from(_: SunCenter) -> Self {
+        Self(10)
+    }
+}
+
+impl From<EarthCenter> for DynCenter {
+    fn from(_: EarthCenter) -> Self {
+        Self(399)
     }
 }
 

--- a/src/kete_core/src/frames/definitions.rs
+++ b/src/kete_core/src/frames/definitions.rs
@@ -158,7 +158,7 @@ pub struct NonInertialFrame {
 impl NonInertialFrame {
     /// Create a new non-inertial frame from the provided rotation and rotation rate.
     pub fn from_euler<const E1: char, const E2: char, const E3: char>(
-        time: Time<TDB>,
+        time: impl Into<Time<TDB>>,
         angles: [f64; 3],
         rates: [f64; 3],
         reference_frame_id: i32,
@@ -166,7 +166,7 @@ impl NonInertialFrame {
     ) -> Self {
         let (rot_p, rot_dp) = euler_rotation::<E1, E2, E3>(&angles, &rates);
         Self {
-            time,
+            time: time.into(),
             rotation: rot_p,
             rotation_rate: Some(rot_dp),
             reference_frame_id,
@@ -183,14 +183,14 @@ impl NonInertialFrame {
     /// * `reference_frame_id` - The frame that this frame is defined relative to.
     /// * `frame_id` - The frame ID of this frame.
     pub fn from_rotations(
-        time: Time<TDB>,
+        time: impl Into<Time<TDB>>,
         rotation: Rotation3<f64>,
         rotation_rate: Option<Matrix3<f64>>,
         reference_frame_id: i32,
         frame_id: i32,
     ) -> Self {
         Self {
-            time,
+            time: time.into(),
             rotation,
             rotation_rate,
             reference_frame_id,
@@ -241,13 +241,14 @@ impl NonInertialFrame {
     )]
     pub fn from_equatorial(
         &self,
-        pos: Vector3<f64>,
-        vel: Vector3<f64>,
+        pos: impl Into<Vector3<f64>>,
+        vel: impl Into<Vector3<f64>>,
     ) -> KeteResult<(Vector3<f64>, Vector3<f64>)> {
+        let pos = pos.into();
         let (rot_p, rot_dp) = self.rotations_to_equatorial()?;
 
         let new_pos = rot_p.inverse_transform_vector(&pos);
-        let new_vel = rot_dp.transpose() * pos + rot_p.inverse_transform_vector(&vel);
+        let new_vel = rot_dp.transpose() * pos + rot_p.inverse_transform_vector(&vel.into());
 
         Ok((new_pos, new_vel))
     }
@@ -259,13 +260,14 @@ impl NonInertialFrame {
     /// Please raise a github issue if this error occurs.
     pub fn to_equatorial(
         &self,
-        pos: Vector3<f64>,
-        vel: Vector3<f64>,
+        pos: impl Into<Vector3<f64>>,
+        vel: impl Into<Vector3<f64>>,
     ) -> KeteResult<(Vector3<f64>, Vector3<f64>)> {
+        let pos = pos.into();
         let (rot_p, rot_dp) = self.rotations_to_equatorial()?;
 
         let new_pos = rot_p.transform_vector(&pos);
-        let new_vel = rot_dp * pos + rot_p.transform_vector(&vel);
+        let new_vel = rot_dp * pos + rot_p.transform_vector(&vel.into());
         Ok((new_pos, new_vel))
     }
 }
@@ -331,10 +333,9 @@ mod tests {
     fn test_noninertial_rot_roundtrip() {
         let angles = [0.11, 0.21, 0.31];
         let rates = [0.41, 0.51, 0.61];
-        let pos = [1.0, 2.0, 3.0].into();
-        let vel = [0.1, 0.2, 0.3].into();
-        let frame =
-            NonInertialFrame::from_euler::<'Z', 'X', 'Z'>(0_f64.into(), angles, rates, 17, 100);
+        let pos = [1.0, 2.0, 3.0];
+        let vel = [0.1, 0.2, 0.3];
+        let frame = NonInertialFrame::from_euler::<'Z', 'X', 'Z'>(0_f64, angles, rates, 17, 100);
         let (r_pos, r_vel) = frame.to_equatorial(pos, vel).unwrap();
         let (pos_return, vel_return) = frame.from_equatorial(r_pos, r_vel).unwrap();
 

--- a/src/kete_core/src/frames/earth.rs
+++ b/src/kete_core/src/frames/earth.rs
@@ -287,7 +287,7 @@ pub fn approx_earth_pos_to_ecliptic(
 
     let rotation = earth_precession_rotation(time);
 
-    let (pos, vel) = rotation.to_equatorial(pos, [0.0; 3].into())?;
+    let (pos, vel) = rotation.to_equatorial(pos, [0.0; 3])?;
 
     Ok(State::<Equatorial>::new(desig, time.tdb(), pos, vel, 399).into_frame())
 }

--- a/src/kete_core/src/frames/earth.rs
+++ b/src/kete_core/src/frames/earth.rs
@@ -289,7 +289,7 @@ pub fn approx_earth_pos_to_ecliptic(
 
     let (pos, vel) = rotation.to_equatorial(pos, [0.0; 3].into())?;
 
-    Ok(State::<Equatorial>::new(desig, time.tdb(), pos.into(), vel.into(), 399).into_frame())
+    Ok(State::<Equatorial>::new(desig, time.tdb(), pos, vel, 399).into_frame())
 }
 
 /// Compute the next sunset and sunrise times for a given location.

--- a/src/kete_core/src/io/parquet.rs
+++ b/src/kete_core/src/io/parquet.rs
@@ -241,9 +241,9 @@ pub fn read_states_parquet(
 
             State::new(
                 crate::desigs::Desig::Name(desig.to_string()),
-                jd.into(),
-                [x, y, z].into(),
-                [vx, vy, vz].into(),
+                jd,
+                [x, y, z],
+                [vx, vy, vz],
                 center_id,
             )
         })

--- a/src/kete_core/src/state.rs
+++ b/src/kete_core/src/state.rs
@@ -130,17 +130,17 @@ where
     /// * `center` - Central body, must implement [`CenterBody`].
     #[inline(always)]
     pub fn new(
-        desig: Desig,
-        epoch: Time<TDB>,
-        pos: Vector<T>,
-        vel: Vector<T>,
+        desig: impl Into<Desig>,
+        epoch: impl Into<Time<TDB>>,
+        pos: impl Into<Vector<T>>,
+        vel: impl Into<Vector<T>>,
         center: impl Into<C>,
     ) -> Self {
         Self {
-            desig,
-            epoch,
-            pos,
-            vel,
+            desig: desig.into(),
+            epoch: epoch.into(),
+            pos: pos.into(),
+            vel: vel.into(),
             center: center.into(),
         }
     }
@@ -150,7 +150,11 @@ where
     /// This is primarily useful as a place holder when propagation has failed
     /// and the object needs to be recorded still.
     #[inline(always)]
-    pub fn new_nan(desig: Desig, epoch: Time<TDB>, center: impl Into<C>) -> Self {
+    pub fn new_nan(
+        desig: impl Into<Desig>,
+        epoch: impl Into<Time<TDB>>,
+        center: impl Into<C>,
+    ) -> Self {
         Self::new(
             desig,
             epoch,
@@ -336,13 +340,7 @@ mod tests {
 
     #[test]
     fn flip_center() {
-        let mut a = State::<Equatorial>::new(
-            Desig::Naif(1),
-            0.0.into(),
-            [1.0, 0.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            0,
-        );
+        let mut a = State::<Equatorial>::new(None, 0.0, [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], 0);
         a.try_flip_center_id().unwrap();
 
         let pos: [f64; 3] = a.pos.into();
@@ -354,28 +352,16 @@ mod tests {
 
     #[test]
     fn nan_finite() {
-        let a = State::<Equatorial>::new(
-            Desig::Naif(1),
-            0.0.into(),
-            [1.0, 0.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            0,
-        );
+        let a = State::<Equatorial>::new(None, 0.0, [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], 0);
         assert!(a.is_finite());
 
-        let b = State::<Equatorial>::new_nan(Desig::Empty, 0.0.into(), 1000);
+        let b = State::<Equatorial>::new_nan(Desig::Empty, 0.0, 1000);
         assert!(!b.is_finite());
     }
 
     #[test]
     fn ssb_round_trip() {
-        let dyn_state = State::<Equatorial>::new(
-            Desig::Naif(1),
-            0.0.into(),
-            [1.0, 2.0, 3.0].into(),
-            [0.1, 0.2, 0.3].into(),
-            0,
-        );
+        let dyn_state = State::<Equatorial>::new(None, 0.0, [1.0, 2.0, 3.0], [0.1, 0.2, 0.3], 0);
         let ssb: State<Equatorial, SSB> = dyn_state.clone().try_into().unwrap();
         let back: State<Equatorial, DynCenter> = ssb.into();
         assert_eq!(dyn_state, back);
@@ -384,10 +370,10 @@ mod tests {
     #[test]
     fn ssb_try_from_wrong_center() {
         let bad = State::<Equatorial>::new(
-            Desig::Naif(1),
-            0.0.into(),
-            [1.0, 0.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
+            None,
+            0.0,
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
             10, // not SSB
         );
         assert!(State::<Equatorial, SSB>::try_from(bad).is_err());
@@ -395,20 +381,8 @@ mod tests {
 
     #[test]
     fn change_center() {
-        let mut a = State::<Ecliptic>::new(
-            Desig::Naif(1),
-            0.0.into(),
-            [1.0, 0.0, 0.0].into(),
-            [1.0, 0.0, 0.0].into(),
-            0,
-        );
-        let b = State::<Equatorial>::new(
-            Desig::Naif(3),
-            0.0.into(),
-            [0.0, 1.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            0,
-        );
+        let mut a = State::<Ecliptic>::new(1, 0.0, [1.0, 0.0, 0.0], [1.0, 0.0, 0.0], 0);
+        let b = State::<Equatorial>::new(3, 0.0, [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], 0);
         a.try_change_center(b.into_frame()).unwrap();
 
         assert!(a.center_id() == 3);
@@ -418,31 +392,14 @@ mod tests {
         assert!(a.vel[0] == 1.0);
 
         // try cases which cause errors
-        let diff_jd = State::<Equatorial>::new(
-            Desig::Naif(3),
-            1.0.into(),
-            [0.0, 1.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            0,
-        );
+        let diff_jd = State::<Equatorial>::new(3, 1.0, [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], 0);
         assert!(a.try_change_center(diff_jd.into_frame()).is_err());
 
-        let not_naif_id = State::<Equatorial>::new(
-            Desig::Empty,
-            0.0.into(),
-            [0.0, 1.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            0,
-        );
+        let not_naif_id = State::<Equatorial>::new(None, 0.0, [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], 0);
         assert!(a.try_change_center(not_naif_id.into_frame()).is_err());
 
-        let no_matching_id = State::<Equatorial>::new(
-            Desig::Naif(2),
-            0.0.into(),
-            [0.0, 1.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            1_000_000_000,
-        );
+        let no_matching_id =
+            State::<Equatorial>::new(2, 0.0, [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], 1_000_000_000);
         assert!(a.try_change_center(no_matching_id.into_frame()).is_err());
     }
 }

--- a/src/kete_core/src/state.rs
+++ b/src/kete_core/src/state.rs
@@ -67,6 +67,7 @@ pub struct State<T, C = DynCenter>
 where
     T: InertialFrame,
     C: CenterBody,
+    DynCenter: From<C>,
 {
     /// Designation number which corresponds to the object.
     pub desig: Desig,
@@ -84,7 +85,10 @@ where
     pub center: C,
 }
 
-impl<T: InertialFrame, C: CenterBody> State<T, C> {
+impl<T: InertialFrame, C: CenterBody> State<T, C>
+where
+    DynCenter: From<C>,
+{
     /// NAIF id of the center body.
     #[inline(always)]
     pub fn center_id(&self) -> i32 {
@@ -112,15 +116,25 @@ impl<T: InertialFrame, C: CenterBody> State<T, C> {
     }
 }
 
-impl<T: InertialFrame> State<T, DynCenter> {
-    /// Construct a new State object with a runtime-determined center.
+impl<T: InertialFrame, C: CenterBody> State<T, C>
+where
+    DynCenter: From<C>,
+{
+    /// Construct a new State object.
+    ///
+    /// # Arguments
+    /// * `desig` - Designation number which corresponds to the object.
+    /// * `epoch` - Epoch of the object's state in TDB scaled time.
+    /// * `pos` - Position of the object with respect to the center body, units of AU.
+    /// * `vel` - Velocity of the object with respect to the center body, units of AU/Day.
+    /// * `center` - Central body, must implement [`CenterBody`].
     #[inline(always)]
     pub fn new(
         desig: Desig,
         epoch: Time<TDB>,
         pos: Vector<T>,
         vel: Vector<T>,
-        center: impl Into<DynCenter>,
+        center: impl Into<C>,
     ) -> Self {
         Self {
             desig,
@@ -136,10 +150,18 @@ impl<T: InertialFrame> State<T, DynCenter> {
     /// This is primarily useful as a place holder when propagation has failed
     /// and the object needs to be recorded still.
     #[inline(always)]
-    pub fn new_nan(desig: Desig, epoch: Time<TDB>, center: impl Into<DynCenter>) -> Self {
-        Self::new(desig, epoch, Vector::new_nan(), Vector::new_nan(), center)
+    pub fn new_nan(desig: Desig, epoch: Time<TDB>, center: impl Into<C>) -> Self {
+        Self::new(
+            desig,
+            epoch,
+            Vector::new_nan(),
+            Vector::new_nan(),
+            center.into(),
+        )
     }
+}
 
+impl<T: InertialFrame> State<T, DynCenter> {
     /// Trade the center ID and ID values, and flip the direction of the position and
     /// velocity vectors.
     #[inline(always)]

--- a/src/kete_core/src/state.rs
+++ b/src/kete_core/src/state.rs
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn flip_center() {
-        let mut a = State::<Equatorial>::new(None, 0.0, [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], 0);
+        let mut a = State::<Equatorial>::new(1, 0.0, [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], 0);
         a.try_flip_center_id().unwrap();
 
         let pos: [f64; 3] = a.pos.into();

--- a/src/kete_fitting/src/filter.rs
+++ b/src/kete_fitting/src/filter.rs
@@ -67,7 +67,10 @@ fn n_nongrav_params(ng: Option<&NonGravModel>) -> usize {
 fn state_to_vec<C: CenterBody>(
     state: &State<Equatorial, C>,
     non_grav: Option<&NonGravModel>,
-) -> DVector<f64> {
+) -> DVector<f64>
+where
+    kete_core::frames::DynCenter: From<C>,
+{
     let np = n_nongrav_params(non_grav);
     let dim = 6 + np;
     let mut xv = DVector::zeros(dim);
@@ -91,7 +94,10 @@ fn vec_to_state<C: CenterBody + Clone>(
     xv: &DVector<f64>,
     template: &State<Equatorial, C>,
     non_grav: &mut Option<NonGravModel>,
-) -> State<Equatorial, C> {
+) -> State<Equatorial, C>
+where
+    kete_core::frames::DynCenter: From<C>,
+{
     let mut state = template.clone();
     state.pos = [xv[0], xv[1], xv[2]].into();
     state.vel = [xv[3], xv[4], xv[5]].into();

--- a/src/kete_fitting/src/horizons.rs
+++ b/src/kete_fitting/src/horizons.rs
@@ -13,7 +13,6 @@ use kete_core::errors::{Error, KeteResult};
 use kete_core::forces::NonGravModel;
 use kete_core::frames::{Ecliptic, Equatorial};
 use kete_core::state::State;
-use kete_core::time::Time;
 use nalgebra::DMatrix;
 #[cfg(feature = "fetch")]
 use serde::Deserialize;
@@ -569,13 +568,7 @@ fn build_uncertain_state(
             "" => Desig::Empty,
             _ => Desig::Name(desig.to_string()),
         };
-        let state: State<Equatorial> = State::new(
-            desig_val,
-            Time::new(epoch),
-            [x, y, z].into(),
-            [vx, vy, vz].into(),
-            10,
-        );
+        let state: State<Equatorial> = State::new(desig_val, epoch, [x, y, z], [vx, vy, vz], 10);
 
         let mat = DMatrix::from_fn(n, n, |r, c| match (reorder[r], reorder[c]) {
             (Some(sr), Some(sc)) => cov_matrix[sr][sc],

--- a/src/kete_fitting/src/iod.rs
+++ b/src/kete_fitting/src/iod.rs
@@ -1239,7 +1239,10 @@ mod tests {
     fn best_candidate<'a, C: kete_core::frames::CenterBody>(
         candidates: &'a [(f64, State<Equatorial>)],
         truth: &State<Equatorial, C>,
-    ) -> &'a State<Equatorial> {
+    ) -> &'a State<Equatorial>
+    where
+        kete_core::frames::DynCenter: From<C>,
+    {
         candidates
             .iter()
             .map(|(_, s)| s)

--- a/src/kete_fitting/src/obs.rs
+++ b/src/kete_fitting/src/obs.rs
@@ -133,8 +133,7 @@ fn station_state_at(
     let frame = pcks.try_get_orientation(3000, epoch)?;
     let (pos_eq, vel_eq) = frame.to_equatorial(pos_ecef_au, Vector3::zeros())?;
 
-    let geocentric =
-        State::<Equatorial>::new(Desig::Empty, epoch, pos_eq.into(), vel_eq.into(), 399);
+    let geocentric = State::<Equatorial>::new(Desig::Empty, epoch, pos_eq, vel_eq, 399);
     let spks = LOADED_SPK.try_read()?;
     spks.try_to_ssb(geocentric)
 }

--- a/src/kete_fitting/src/uncertain_state.rs
+++ b/src/kete_fitting/src/uncertain_state.rs
@@ -245,14 +245,12 @@ impl UncertainState {
                     nominal[0] + delta[0],
                     nominal[1] + delta[1],
                     nominal[2] + delta[2],
-                ]
-                .into(),
+                ],
                 [
                     nominal[3] + delta[3],
                     nominal[4] + delta[4],
                     nominal[5] + delta[5],
-                ]
-                .into(),
+                ],
                 self.state.center_id(),
             );
 
@@ -387,10 +385,10 @@ mod tests {
         State::new(
             Desig::Name("Test".into()),
             // J2000.0
-            Time::new(2451545.0),
-            [1.0, 0.0, 0.0].into(),
+            2451545.0,
+            [1.0, 0.0, 0.0],
             // ~1 AU circular
-            [0.0, 0.01720209895, 0.0].into(),
+            [0.0, 0.01720209895, 0.0],
             10,
         )
     }

--- a/src/kete_spice/benches/propagation.rs
+++ b/src/kete_spice/benches/propagation.rs
@@ -16,27 +16,27 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 static CIRCULAR: std::sync::LazyLock<State<Ecliptic>> = std::sync::LazyLock::new(|| {
     State::new(
         Desig::Name("Circular".into()),
-        2451545.0.into(),
-        [0.0, 1., 0.0].into(),
-        [-constants::GMS_SQRT, 0.0, 0.0].into(),
+        2451545.0,
+        [0.0, 1., 0.0],
+        [-constants::GMS_SQRT, 0.0, 0.0],
         0,
     )
 });
 static ELLIPTICAL: std::sync::LazyLock<State<Ecliptic>> = std::sync::LazyLock::new(|| {
     State::new(
         Desig::Name("Elliptical".into()),
-        2451545.0.into(),
-        [0.0, 1.5, 0.0].into(),
-        [-constants::GMS_SQRT, 0.0, 0.0].into(),
+        2451545.0,
+        [0.0, 1.5, 0.0],
+        [-constants::GMS_SQRT, 0.0, 0.0],
         0,
     )
 });
 static PARABOLIC: std::sync::LazyLock<State<Ecliptic>> = std::sync::LazyLock::new(|| {
     State::new(
         Desig::Name("Parabolic".into()),
-        2451545.0.into(),
-        [0.0, 2., 0.0].into(),
-        [-constants::GMS_SQRT, 0.0, 0.0].into(),
+        2451545.0,
+        [0.0, 2., 0.0],
+        [-constants::GMS_SQRT, 0.0, 0.0],
         0,
     )
 });
@@ -44,9 +44,9 @@ static PARABOLIC: std::sync::LazyLock<State<Ecliptic>> = std::sync::LazyLock::ne
 static HYPERBOLIC: std::sync::LazyLock<State<Ecliptic>> = std::sync::LazyLock::new(|| {
     State::new(
         Desig::Name("Hyperbolic".into()),
-        2451545.0.into(),
-        [0.0, 3., 0.0].into(),
-        [-constants::GMS_SQRT, 0.0, 0.0].into(),
+        2451545.0,
+        [0.0, 3., 0.0],
+        [-constants::GMS_SQRT, 0.0, 0.0],
         0,
     )
 });

--- a/src/kete_spice/src/fov_checks.rs
+++ b/src/kete_spice/src/fov_checks.rs
@@ -186,16 +186,16 @@ mod tests {
         crate::test_data::ensure_test_spk();
         let circular = State::new(
             Desig::Empty,
-            2451545.0.into(),
-            [0.0, 1., 0.0].into(),
-            [-GMS_SQRT, 0.0, 0.0].into(),
+            2451545.0,
+            [0.0, 1., 0.0],
+            [-GMS_SQRT, 0.0, 0.0],
             10,
         );
         let circular_back = State::new(
             Desig::Empty,
-            2451545.0.into(),
-            [1.0, 0.0, 0.0].into(),
-            [0.0, GMS_SQRT, 0.0].into(),
+            2451545.0,
+            [1.0, 0.0, 0.0],
+            [0.0, GMS_SQRT, 0.0],
             10,
         );
 
@@ -243,9 +243,9 @@ mod tests {
         let spk = &LOADED_SPK.read().unwrap();
         let observer = State::new(
             Desig::Empty,
-            2451545.0.into(),
-            [0.0, 1., 0.0].into(),
-            [-GMS_SQRT, 0.0, 0.0].into(),
+            2451545.0,
+            [0.0, 1., 0.0],
+            [-GMS_SQRT, 0.0, 0.0],
             10,
         );
 

--- a/src/kete_spice/src/propagation.rs
+++ b/src/kete_spice/src/propagation.rs
@@ -421,7 +421,7 @@ pub fn propagate_n_body_vec(
     for (idx, desig) in desigs.into_iter().enumerate() {
         let pos = pos.fixed_rows::<3>(idx * 3) - sun_pos;
         let vel = vel.fixed_rows::<3>(idx * 3) - sun_vel;
-        let state = State::new(desig, jd_final, pos.into(), vel.into(), 10);
+        let state = State::new(desig, jd_final, pos, vel, 10);
         all_states.push(state);
     }
     let final_states = all_states.split_off(GravParams::simplified_planets().len());

--- a/src/kete_spice/src/spk/segments.rs
+++ b/src/kete_spice/src/spk/segments.rs
@@ -141,32 +141,32 @@ impl SpkSegment {
             1 => Ok(State::<Equatorial>::new(
                 Desig::Naif(arr_ref.object_id),
                 jd,
-                pos.into(),
-                vel.into(),
+                pos,
+                vel,
                 arr_ref.center_id,
             )
             .into_frame()),
             3 => Ok(State::<FK4>::new(
                 Desig::Naif(arr_ref.object_id),
                 jd,
-                pos.into(),
-                vel.into(),
+                pos,
+                vel,
                 arr_ref.center_id,
             )
             .into_frame()),
             13 => Ok(State::<Galactic>::new(
                 Desig::Naif(arr_ref.object_id),
                 jd,
-                pos.into(),
-                vel.into(),
+                pos,
+                vel,
                 arr_ref.center_id,
             )
             .into_frame()),
             17 => Ok(State::<Ecliptic>::new(
                 Desig::Naif(arr_ref.object_id),
                 jd,
-                pos.into(),
-                vel.into(),
+                pos,
+                vel,
                 arr_ref.center_id,
             )
             .into_frame()),


### PR DESCRIPTION
Ergonomics of building non-dynamic center ID states was annoying. This PR generalizes to allow constructions such as:

``` rust
   let s = State<Equatorial> = State::new(None, 1.0, [1.0, 0.0, 0.0], [0.0, 0.0, 0.0], SunCenter)
```